### PR TITLE
Role Enum의 값에 prefix "ROLE_" 추가

### DIFF
--- a/src/main/java/kr/hellogsm/back_v2/domain/user/entity/User.java
+++ b/src/main/java/kr/hellogsm/back_v2/domain/user/entity/User.java
@@ -30,7 +30,7 @@ public class User {
 
     @PrePersist
     private void prePersist() {
-        this.role = this.role == null ? Role.UNAUTHENTICATED : this.role;
+        this.role = this.role == null ? Role.ROLE_UNAUTHENTICATED : this.role;
     }
 
 }

--- a/src/main/java/kr/hellogsm/back_v2/domain/user/enums/Role.java
+++ b/src/main/java/kr/hellogsm/back_v2/domain/user/enums/Role.java
@@ -1,7 +1,7 @@
 package kr.hellogsm.back_v2.domain.user.enums;
 
 public enum Role {
-    UNAUTHENTICATED,
-    USER,
-    ADMIN
+    ROLE_UNAUTHENTICATED,
+    ROLE_USER,
+    ROLE_ADMIN
 }


### PR DESCRIPTION
## 개요

Role Enum의 Type에 "ROLE_" prefix 를 추가하였습니다.

## 본문

Authentication객체의 Authority 중 Role을 의미하는 Authority는 앞에 "ROLE_" 이 추가되어야 합니다.
기존의 코드에는 누락되어 있어서 추가하였습니다.
