### PR TITLE
404 예외처리 기능 추가

### DIFF
--- a/src/main/java/kr/hellogsm/back_v2/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/hellogsm/back_v2/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,14 +22,15 @@ import java.util.Map;
  * @author 양시준
  * @since 1.0.0
  */
-@RestControllerAdvice
 @Slf4j
+@EnableWebMvc
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
     /**
      * 커스텀 에러인 {@code ExpectedException}을 포함한 하위 에러를 핸들링합니다. <br>
      *
-     * @param ex {@code ExpectedException}을 포함한 {@code ExpectedException}을 상속하는 클래스
+     * @param ex {@code ExpectedException}을 포함한 {@code ExpectedException}을 상속하는 객체
      * @return ResponseEntity
      */
     @ExceptionHandler(ExpectedException.class)
@@ -37,13 +40,12 @@ public class GlobalExceptionHandler {
     }
 
 
-
     /**
      * {@code @Valid} 검증에 실패한 경우 던져지는 {@code MethodArgumentNotValidException}를 핸들링합니다.
      *
      * <p>
      * 반환 메시지 예시:
-     *  <pre>
+     * <pre>
      *  {@code
      * {
      *    "message": "{'testDto':{'password':'널이어서는 안됩니다','data':'최대 길이인 5를 넘어감니다'}}"
@@ -51,10 +53,8 @@ public class GlobalExceptionHandler {
      * }
      * </pre>
      *
-     *
      * @param ex {@code MethodArgumentNotValidException}
      * @return ResponseEntity
-     *
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponseEntity> validationException(MethodArgumentNotValidException ex) {
@@ -65,7 +65,7 @@ public class GlobalExceptionHandler {
     /**
      * 예외처리하지 않은 {@code RuntimeException} 포함한 하위 에러를 핸들링합니다. <br>
      *
-     * @param ex {@code RuntimeException}또는 {@code RuntimeException}을 상속하는 클래스
+     * @param ex {@code RuntimeException}또는 {@code RuntimeException}을 상속하는 객체
      * @return ResponseEntity
      */
     @ExceptionHandler(RuntimeException.class)
@@ -77,6 +77,18 @@ public class GlobalExceptionHandler {
 
     //  만약 ConstraintViolationException 에러가 발생했다면 JPA에서 valid 문제가 생긴건데,
     //  비즈니스 로직을 잘못 짰거나, Request DTO 에서 검증을 잘못했단 뜻이니까. BE 개발자의 문제이므로 코드를 고칠 필요가 있다.
+
+    /**
+     * {@code NoHandlerFoundException}을 처리하는 메소드입니다.
+     *
+     * @param ex NoHandlerFoundException 객체
+     * @return ResponseEntity
+     */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ExceptionResponseEntity> noHandlerFoundException(NoHandlerFoundException ex) {
+        return ResponseEntity.status(ex.getStatusCode())
+                .body(new ExceptionResponseEntity(HttpStatus.NOT_FOUND.getReasonPhrase()));
+    }
 
     private static String methodArgumentNotValidExceptionToJson(MethodArgumentNotValidException ex) {
         Map<String, Object> globalResults = new HashMap<>();


### PR DESCRIPTION
## 개요

기본적으로 스프링은 DispatcherServlet이 요청에 대한 handler를 찾을 수 없으면 NoHandlerFoundException 에러를 발생시켜 사용자에게 404 에러 페이지를 전달합니다.
NoHandlerFoundException에러를 핸들링하여 스프링에서 기본 제공하는 404 페이지 대신 rest한 방식으로 전달하는 기능을 추가하였습니다.

## 본문

### 참고

`@EnableWebMvc`는 기존에 스프링에 제공하는 404 에러 메세지, 500 에러 메세지를 비활성화합니다.
404 에러와 500 에러 모두 커스텀 한 예외처리를 제공하기 때문에 비활성화 하여도 무방합니다.
