### PR TITLE
fix(user): UserDto 생성자 argument 값 수정

### DIFF
--- a/src/main/java/kr/hellogsm/back_v2/domain/user/dto/domain/UserDto.java
+++ b/src/main/java/kr/hellogsm/back_v2/domain/user/dto/domain/UserDto.java
@@ -19,7 +19,7 @@ public record UserDto(
         return new UserDto (
                 user.getId(),
                 user.getProvider(),
-                user.getProvider(),
+                user.getProviderId(),
                 user.getRole()
         );
     }


### PR DESCRIPTION
## 개요
UserDto의 from() 메서드 수정

## 본문

UserDto 클래스의 from() 메서드에서 사용하는 생성자의 인수 중 ProviderId의 값으로 Provider 값이 들어가도록 잘못 작성한 로직을 수정하였습니다.



