### PR TITLE
fix(global): Security Config 보완

### DIFF
--- a/src/main/java/kr/hellogsm/back_v2/domain/user/enums/Role.java
+++ b/src/main/java/kr/hellogsm/back_v2/domain/user/enums/Role.java
@@ -1,7 +1,18 @@
 package kr.hellogsm.back_v2.domain.user.enums;
 
 public enum Role {
-    ROLE_UNAUTHENTICATED,
-    ROLE_USER,
-    ROLE_ADMIN
+
+    ROLE_UNAUTHENTICATED("UNAUTHENTICATED"),
+    ROLE_USER("USER"),
+    ROLE_ADMIN("ADMIN");
+
+    private final String role;
+
+    Role(String role) {
+        this.role = role;
+    }
+
+    public String getRole() {
+        return role;
+    }
 }

--- a/src/main/java/kr/hellogsm/back_v2/global/data/profile/ServerProfile.java
+++ b/src/main/java/kr/hellogsm/back_v2/global/data/profile/ServerProfile.java
@@ -1,0 +1,11 @@
+package kr.hellogsm.back_v2.global.data.profile;
+
+public class ServerProfile {
+
+    public static final String LOCAL = "local";
+    public static final String PROD = "prod";
+
+    private ServerProfile() {
+        throw new IllegalStateException("인스턴스 생성이 불가능한 클래스입니다");
+    }
+}

--- a/src/main/java/kr/hellogsm/back_v2/global/security/SecurityConfig.java
+++ b/src/main/java/kr/hellogsm/back_v2/global/security/SecurityConfig.java
@@ -1,12 +1,24 @@
 package kr.hellogsm.back_v2.global.security;
 
+import kr.hellogsm.back_v2.domain.user.enums.Role;
+import kr.hellogsm.back_v2.global.data.profile.ServerProfile;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
 
 /**
  * SecurityConfig <br>
@@ -17,53 +29,120 @@ import org.springframework.security.web.SecurityFilterChain;
  * @since 1.0.0
  */
 @Configuration
-@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    @Value("${oauth2.redirect-base-uri}")
-    String redirectBaseUri;
-    private final String logoutUri = "/auth/v1/auth/logout";
-    // /auth/v1/auth/oauth2/authorization/google
-    private final String oauth2LoginEndpointBaseUri = "/auth/v1/auth/oauth2/authorization";
+
+    @Value("${auth.redirect-base-uri}")
+    private String redirectBaseUri;
+
+    @Value("${auth.allowed-origins}")
+    private List<String> AllowedOrigins;
+
+    private static final String logoutUri = "/auth/v1/logout";
+    private static final String oauth2LoginEndpointBaseUri = "/auth/v1/oauth2/authorization";
+    private static final String oauth2LoginProcessingUri = "/auth/v1/oauth2/code/*";
+
 
     // TODO
-    //  1. OAuth 인증 관련 필터 추가 - ok
-    //  2. Logout~Handler 구현 - REST - ok
-    //  3. 필터 예외처리 추가 - ok
-    //  4. inner class로 프로필 별 셜졍 관리 - hirecruit 참고
-    //  5. 본인인증 필터 추가
+    //  1. 본인인증 필터 추가
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        csrf(http);
-        http
-                .headers(header -> header
-                        .frameOptions()
-                        .sameOrigin()
-                )
-                .authorizeHttpRequests(httpRequests -> httpRequests
-                        .requestMatchers("/h2").permitAll()
-                        .requestMatchers("/auth/v1/**").permitAll()
-                        .requestMatchers("/user/v1/**").authenticated()
-                        .requestMatchers("/identity/v1/**").authenticated()
-                        .anyRequest().permitAll()
-                )
-                .oauth2Login(oauth2Login ->
-                        oauth2Login
-                                .authorizationEndpoint().baseUri(oauth2LoginEndpointBaseUri).and()
-                                .defaultSuccessUrl(redirectBaseUri)
+    @Configuration
+    @EnableWebSecurity
+    @Profile(ServerProfile.LOCAL)
+    public class LocalSecurityConfig {
 
-                )
-                .logout(logout -> logout
-                        .logoutUrl(logoutUri)
-                        .logoutSuccessUrl(redirectBaseUri))
-                .formLogin().disable()
-                .httpBasic().disable();
-        return http.build();
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            http
+                    .formLogin().disable()
+                    .httpBasic().disable()
+                    .cors().disable()
+                    .headers().frameOptions().sameOrigin();
+            csrf(http);
+            logout(http);
+            oauth2Login(http);
+            http.authorizeHttpRequests(
+                    httpRequests -> httpRequests
+                            .requestMatchers(toH2Console()).permitAll()
+            );
+            authorizeHttpRequests(http);
+            return http.build();
+        }
     }
 
-    private HttpSecurity csrf(HttpSecurity http) throws Exception {
-        return http.csrf().disable();
+    @Configuration
+    @EnableWebSecurity
+    @Profile(ServerProfile.PROD)
+    public class ProdSecurityConfig {
+
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            http
+                    .formLogin().disable()
+                    .httpBasic().disable()
+                    .cors().configurationSource(corsConfigurationSource());
+            csrf(http);
+            logout(http);
+            oauth2Login(http);
+            authorizeHttpRequests(http);
+            return http.build();
+        }
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(AllowedOrigins);
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+    private void csrf(HttpSecurity http) throws Exception {
+        http.csrf();
+    }
+
+    private void oauth2Login(HttpSecurity http) throws Exception {
+        http.oauth2Login(oauth2Login ->
+                oauth2Login
+                        .authorizationEndpoint().baseUri(oauth2LoginEndpointBaseUri).and()
+                        .loginProcessingUrl(oauth2LoginProcessingUri)
+                        .defaultSuccessUrl(redirectBaseUri)
+
+        );
+    }
+
+    private void logout(HttpSecurity http) throws Exception {
+        http.logout(logout -> logout
+                .logoutUrl(logoutUri)
+                .logoutSuccessUrl(redirectBaseUri)
+        );
+    }
+
+    private void authorizeHttpRequests(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(httpRequests -> httpRequests
+                .requestMatchers("/auth/v1/**").permitAll()
+                .requestMatchers("/user/v1/**").hasAnyRole(
+                        Role.ROLE_UNAUTHENTICATED.getRole(),
+                        Role.ROLE_USER.getRole(),
+                        Role.ROLE_ADMIN.getRole()
+                )
+                .requestMatchers(HttpMethod.POST, "/identity/v1/**").hasAnyRole(
+                        Role.ROLE_UNAUTHENTICATED.getRole(),
+                        Role.ROLE_USER.getRole(),
+                        Role.ROLE_ADMIN.getRole()
+                )
+                .requestMatchers("/identity/v1/**").hasAnyRole(
+                        Role.ROLE_USER.getRole(),
+                        Role.ROLE_ADMIN.getRole()
+                )
+                .requestMatchers("/application/v1/**").hasAnyRole(
+                        Role.ROLE_USER.getRole(),
+                        Role.ROLE_ADMIN.getRole()
+                )
+                .anyRequest().denyAll()
+        );
     }
 
 }


### PR DESCRIPTION
## 개요

Spring Security Config 파일을 개선하였습니다.

## 본문

### 추가

1.  CORS 설정 추가
    -   외부에서 CORS AllowedOrigins를 할당할 수 있도록 작성하였습니다.
2.  ServerProfile 클래스 추가
    -   어플리케이션에서 사용하는 Profile을 정의한 ServerProfile 클래스를 추가하였습니다.
    -   Profile 별로 다른 SecurityConfig 설정을 가지게 하도록 하기 위해서 생성했습니다.
4.  `Role` Enum에 `getRole()` 메서드 추가
    -   `SecurityConfig` 클래스의 `.authorizeHttpRequests()`에서 `.hasAnyRole()`을 사용하여 특정 Role을 가져야 요청을 통과하도록 하고 있습니다.
    -   `.hasAnyRole()`의 인자로 들어가는 String은 `ROLE_` Prefix가 없어야 합니다. (예: ROLE_USER(X), USER(O))
    -   그래서 `ROLE_` Prefix를 제외한 String을 반환하는 `getRole()` 메서드를 추가하였습니다.

### 변경

1.  OAuth2 인증 시 code를 받는 URI를 다른 URI 처럼 `/auth/v1/~~`  같은 형태로 변경했습니다.
2.  OAuth2 로그인 엔드포인트를 더 통일성 있는 이름으로 수정했습니다.
    -   `/auth/v1/auth/oauth2/authorization` -> `/auth/v1/oauth2/authorization`
3.  Security Config 설정을 Profile에 따라 다르게 처리되도록 변경했습니다.
    -   여러 Profile에서 공유하는 설정은 메서드로 분리하여 재사용 가능하도록 분리하였습니다.
    -   LOCAL 환경의 경우 개발 편의를 위한 설정을 추가하도록 작성했습니다. (h2 console uri 허용, cors disable 등).
5.  `.authorizeHttpRequests()`에 구체적인 설정을 추가하였습니다.
    -   사용자의 Role에 따라 접근 가능한 URI를 제한하도록 변경했습니다.

### 피드백
#### Security Config 가독성 피드백
저는 코드가 익숙해져서 객관적으로 가독성이 좋은지 평가하기가 어렵습니다.
SecurityConfig 클래스의 코드 중 가독성이 낮아서 수정이 필요하거나, 더 가독성 좋게 작성 가능한 부분이 있으면 알려주세요.