### PR TITLE
[web:global/security] MapStruct 라이브러리 도입

### DIFF
--- a/hellogsm-web/build.gradle
+++ b/hellogsm-web/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     /** for test **/
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    /** code generator **/
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor "org.mapstruct:mapstruct-processor:1.5.5.Final"
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 }
 
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/domain/IdentityDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/domain/IdentityDto.java
@@ -5,14 +5,8 @@ import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
 public record IdentityDto(
         Long id,
         String name,
-        String phoneNumber
+        String phoneNumber,
+        Long userId
 
 ) {
-    public static IdentityDto from(Identity identity) {
-        return new IdentityDto(
-                identity.getId(),
-                identity.getName(),
-                identity.getPhoneNumber()
-        );
-    }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/CreateIdentityReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/CreateIdentityReqDto.java
@@ -10,12 +10,4 @@ public record CreateIdentityReqDto(
         @NotNull
         String phoneNumber
 ) {
-    public Identity toEntity(Long userId) {
-        return new Identity(
-                null,
-                name,
-                phoneNumber,
-                userId
-        );
-    }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
@@ -1,0 +1,35 @@
+package team.themoment.hellogsm.web.domain.identity.mapper;
+
+import org.mapstruct.*;
+import org.mapstruct.factory.Mappers;
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedSourcePolicy = ReportingPolicy.ERROR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR,
+        typeConversionPolicy = ReportingPolicy.WARN
+)
+public interface IdentityMapper {
+    IdentityMapper INSTANCE = Mappers.getMapper(IdentityMapper.class);
+
+    @Mappings({
+            @Mapping(source = "id", target = "id"),
+            @Mapping(source = "name", target = "name"),
+            @Mapping(source = "phoneNumber", target = "phoneNumber"),
+            @Mapping(source = "userId", target = "userId")
+    })
+    IdentityDto identityToIdentityDto(Identity identity);
+
+    // MapStruct 써서 구현하기 힘들어서 걍 함
+    default Identity CreateIdentityReqDtoToIdentity(CreateIdentityReqDto createIdentityReqDto, Long userId) {
+        return new Identity(
+                null,
+                createIdentityReqDto.name(),
+                createIdentityReqDto.phoneNumber(),
+                userId
+        );
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
@@ -9,6 +9,7 @@ import team.themoment.hellogsm.entity.domain.user.entity.User;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.mapper.IdentityMapper;
 import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
 import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
@@ -50,7 +51,8 @@ public class CreateIdentityServiceImpl implements CreateIdentityService {
                 Role.ROLE_USER
         );
         userRepository.save(identifiedUser);
-        Identity identity = identityRepository.save(identityReqDto.toEntity(userId));
-        return IdentityDto.from(identity);
+        Identity newIdentity = IdentityMapper.INSTANCE.CreateIdentityReqDtoToIdentity(identityReqDto, userId);
+        Identity savedidentity = identityRepository.save(newIdentity);
+        return IdentityMapper.INSTANCE.identityToIdentityDto(savedidentity);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/IdentityQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/IdentityQueryImpl.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
+import team.themoment.hellogsm.web.domain.identity.mapper.IdentityMapper;
 import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
 import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
@@ -32,6 +33,6 @@ public class IdentityQueryImpl implements IdentityQuery {
     public IdentityDto execute(Long userId) {
         Identity identity = identityRepository.findByUserId(userId)
                 .orElseThrow(() -> new ExpectedException("존재하지 않는 Identity 입니다", HttpStatus.BAD_REQUEST));
-        return IdentityDto.from(identity);
+        return IdentityMapper.INSTANCE.identityToIdentityDto(identity);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/dto/domain/UserDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/dto/domain/UserDto.java
@@ -2,7 +2,6 @@ package team.themoment.hellogsm.web.domain.user.dto.domain;
 
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import team.themoment.hellogsm.entity.domain.user.entity.User;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
 
 import java.io.Serializable;
@@ -15,12 +14,4 @@ public record UserDto(
         @Enumerated(EnumType.STRING)
         Role role
 ) implements Serializable {
-    public static UserDto from(User user) {
-        return new UserDto (
-                user.getId(),
-                user.getProvider(),
-                user.getProviderId(),
-                user.getRole()
-        );
-    }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/dto/mapper/UserMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/dto/mapper/UserMapper.java
@@ -1,0 +1,36 @@
+package team.themoment.hellogsm.web.domain.user.dto.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+import team.themoment.hellogsm.entity.domain.user.entity.User;
+import team.themoment.hellogsm.web.domain.user.dto.request.CreateUserReqDto;
+import team.themoment.hellogsm.web.domain.user.dto.domain.UserDto;
+
+@Mapper(
+        componentModel = "spring",
+        unmappedSourcePolicy = ReportingPolicy.ERROR,
+        unmappedTargetPolicy = ReportingPolicy.ERROR,
+        typeConversionPolicy = ReportingPolicy.WARN
+)
+public interface UserMapper {
+    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+    @Mappings({
+            @Mapping(source = "id", target = "id"),
+            @Mapping(source = "provider", target = "provider"),
+            @Mapping(source = "providerId", target = "providerId"),
+            @Mapping(source = "role", target = "role")
+    })
+    UserDto userToUserDto(User user);
+
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(source = "provider", target = "provider"),
+            @Mapping(source = "providerId", target = "providerId"),
+            @Mapping(target = "role", ignore = true)
+    })
+    User createUserReqDtoToUser(CreateUserReqDto createUserReqDto);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/dto/request/CreateUserReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/dto/request/CreateUserReqDto.java
@@ -10,12 +10,4 @@ public record CreateUserReqDto(
         @NotNull
         String providerId
 ) {
-    public User toEntity() {
-        return new User(
-                null,
-                provider,
-                providerId,
-                null
-        );
-    }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/CreateUserServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/CreateUserServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsm.entity.domain.user.entity.User;
+import team.themoment.hellogsm.web.domain.user.dto.mapper.UserMapper;
 import team.themoment.hellogsm.web.domain.user.dto.domain.UserDto;
 import team.themoment.hellogsm.web.domain.user.dto.request.CreateUserReqDto;
 import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
@@ -15,14 +16,13 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 @RequiredArgsConstructor
 @Transactional(rollbackFor = {Exception.class})
 public class CreateUserServiceImpl implements CreateUserService {
-
     private final UserRepository userRepository;
 
     @Override
     public UserDto execute(CreateUserReqDto createUserReqDto) {
         checkExistUser(createUserReqDto);
-        User savedTemp = userRepository.save(createUserReqDto.toEntity());
-        return UserDto.from(savedTemp);
+        User savedTemp = userRepository.save(UserMapper.INSTANCE.createUserReqDtoToUser(createUserReqDto));
+        return UserMapper.INSTANCE.userToUserDto(savedTemp);
     }
 
     private void checkExistUser(CreateUserReqDto createUserReqDto) {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/ExistUserQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/ExistUserQueryImpl.java
@@ -8,7 +8,6 @@ import team.themoment.hellogsm.web.domain.user.service.ExistUserQuery;
 @Service
 @RequiredArgsConstructor
 public class ExistUserQueryImpl implements ExistUserQuery {
-
     private final UserRepository userRepository;
 
     @Override

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/UserByIdQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/UserByIdQueryImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.entity.domain.user.entity.User;
+import team.themoment.hellogsm.web.domain.user.dto.mapper.UserMapper;
 import team.themoment.hellogsm.web.domain.user.dto.domain.UserDto;
 import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
 import team.themoment.hellogsm.web.domain.user.service.UserByIdQuery;
@@ -12,14 +13,12 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 @Service
 @RequiredArgsConstructor
 public class UserByIdQueryImpl implements UserByIdQuery {
-
     private final UserRepository userRepository;
 
     @Override
     public UserDto execute(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("존재하지 않는 User 입니다", HttpStatus.BAD_REQUEST));
-
-        return UserDto.from(user);
+        return UserMapper.INSTANCE.userToUserDto(user);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/UserByProviderQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/UserByProviderQueryImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.entity.domain.user.entity.User;
+import team.themoment.hellogsm.web.domain.user.dto.mapper.UserMapper;
 import team.themoment.hellogsm.web.domain.user.dto.domain.UserDto;
 import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
 import team.themoment.hellogsm.web.domain.user.service.UserByProviderQuery;
@@ -18,6 +19,6 @@ public class UserByProviderQueryImpl implements UserByProviderQuery {
     public UserDto execute(String provider, String providerId) {
         User user = userRepository.findByProviderAndProviderId(provider, providerId)
                 .orElseThrow(() -> new ExpectedException("존재하지 않는 User 입니다", HttpStatus.BAD_REQUEST));
-        return UserDto.from(user);
+        return UserMapper.INSTANCE.userToUserDto(user);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/oauth/CustomOauth2UserService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/oauth/CustomOauth2UserService.java
@@ -1,7 +1,7 @@
 package team.themoment.hellogsm.web.global.security.oauth;
 
 import team.themoment.hellogsm.entity.domain.user.entity.User;
-import team.themoment.hellogsm.web.domain.user.dto.domain.UserDto;
+import team.themoment.hellogsm.web.domain.user.dto.mapper.UserMapper;
 import team.themoment.hellogsm.web.domain.user.dto.request.CreateUserReqDto;
 import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -33,14 +33,14 @@ public class CustomOauth2UserService implements OAuth2UserService {
 
         User user = getUser(provider, providerId);
 
-        return new UserInfo(UserDto.from(user), LocalDateTime.now());
+        return new UserInfo(UserMapper.INSTANCE.userToUserDto(user), LocalDateTime.now());
     }
 
     private User getUser(String provider, String providerId) {
         User savedUser = userRepository.findByProviderAndProviderId(provider, providerId)
                 .orElse(null);
         if (savedUser == null) {
-            User user = new CreateUserReqDto(provider, providerId).toEntity();
+            User user = UserMapper.INSTANCE.createUserReqDtoToUser(new CreateUserReqDto(provider, providerId));
             return userRepository.save(user);
         }
         return savedUser;


### PR DESCRIPTION
## 개요
MapStruct 라이브러리를 도입하고, 기존의 코드를 MapStruct 라이브러리를 사용하도록 변경하였습니다.

## 본문
### MapStruct 도입 이유
매핑에 사용되는 필드의 개수가 많다. (가장 필드가 많은 DTO는 40여개의 필드를 가진다.)
이로 인해, 객체 간 매핑 작업으로 인한 시간 소요가 작업에 큰 비중을 차지했다.
작업 효율을 위해 도입하게 되었다.
### 변경 
기존의 각 DTO에 존재하던 매핑 로직을 `~~Mapper` 클래스가 매핑 로직을 처리합니다.
`IdentityDto`에 누락되었던 userId 필드를 추가하였습니다.
