### PR TITLE
[#54] ApplicationReqDto 오타 수정 (.applicantBrith() -> .applicantBirth())

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationReqDto.java
@@ -125,7 +125,7 @@ public record ApplicationReqDto(
                 .applicantImageUri(this.applicantImageUri)
                 .applicantName(this.applicantName)
                 .applicantGender(this.applicantGender)
-                .applicantBrith(this.applicantBirth)
+                .applicantBirth(this.applicantBirth)
                 .address(this.address)
                 .detailAddress(this.detailAddress)
                 .graduation(graduationStatus)


### PR DESCRIPTION
## 개요

`ApplicationReqDto`의 `toEntity()` 메서드의 오타를 수정하였습니다.

## 본문
아래와 같이 변경하였습니다.
`applicantBirth` -> `applicantBrith`
