### PR TITLE
UserDto에 Security 관련 의존성 제거

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/dto/domain/UserDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/dto/domain/UserDto.java
@@ -10,8 +10,7 @@ public record UserDto(
         Long id,
         String provider,
         String providerId,
-
         @Enumerated(EnumType.STRING)
         Role role
-) implements Serializable {
+) {
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/oauth/CustomOauth2UserService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/oauth/CustomOauth2UserService.java
@@ -33,7 +33,7 @@ public class CustomOauth2UserService implements OAuth2UserService {
 
         User user = getUser(provider, providerId);
 
-        return new UserInfo(UserMapper.INSTANCE.userToUserDto(user), LocalDateTime.now());
+        return new UserInfo(user, LocalDateTime.now());
     }
 
     private User getUser(String provider, String providerId) {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/oauth/UserInfo.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/oauth/UserInfo.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.global.security.oauth;
 
+import team.themoment.hellogsm.entity.domain.user.entity.User;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
 import team.themoment.hellogsm.web.domain.user.dto.domain.UserDto;
 import org.springframework.security.core.GrantedAuthority;
@@ -13,25 +14,29 @@ import java.util.List;
 import java.util.Map;
 
 public class UserInfo implements OAuth2User, Serializable {
-    private final UserDto userDto;
+    private final Long userId;
+    private final Role userRole;
+    private final String userName;
     private final LocalDateTime lastLoginTime;
 
-    public UserInfo(UserDto userDto, LocalDateTime lastLoginTime) {
-        this.userDto = userDto;
+    public UserInfo(User user, LocalDateTime lastLoginTime) {
+        this.userId = user.getId();
+        this.userRole = user.getRole();
+        this.userName = user.getProvider() + "_" + user.getProviderId();
         this.lastLoginTime = lastLoginTime;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(userDto.role().name()));
+        return List.of(new SimpleGrantedAuthority(userRole.name()));
     }
 
     public Role getUserRole() {
-        return userDto.role();
+        return userRole;
     }
 
     public Long getUserId() {
-        return userDto.id();
+        return userId;
     }
 
     public LocalDateTime getLastLoginTime() {
@@ -40,7 +45,7 @@ public class UserInfo implements OAuth2User, Serializable {
 
     @Override
     public String getName() {
-        return userDto.provider() + "_" + userDto.providerId();
+        return userName;
     }
 
     /**


### PR DESCRIPTION
## 개요
`UserDto`에 인증 관련 의존성을 제거하였습니다.

## 본문

세션에 저장되는 인증 정보가 담긴 클래스 `UserInfo`에 `UserDto`가 필드로 사용되었습니다.
이로 인해 `UserDto`는 `Serializable`를 구현해야만 했습니다.

`UserInfo`에 `UserDto`가 사용되지 않도록 변경하여, `UserDto`가  `Serializable`를 구현하지 않도록 변경하였습니다.

### 기타 

변경 가능성이 적다고 생각해서, 세션에 저장될 유저 정보를 저장하는 클래스를 만들지 않고 `UserInfo`에 필드로 유저 정보를 저장하도록 구현 하였습니다.
