### PR TITLE
UserInfo, CustomOauth2UserService 리팩토링 및 `@AuthenticationPrincipal` 대체

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -6,6 +6,7 @@ import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplica
 import team.themoment.hellogsm.web.domain.application.service.CreateApplicationService;
 import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationService;
 import team.themoment.hellogsm.web.domain.application.service.QuerySingleApplicationService;
+import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 import team.themoment.hellogsm.web.global.security.oauth.UserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,6 +26,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 @RequestMapping("/application/v1")
 public class ApplicationController {
+    private final AuthenticatedUserManager manager;
     private final CreateApplicationService createApplicationService;
     private final ModifyApplicationService modifyApplicationService;
     private final QuerySingleApplicationService querySingleApplicationService;
@@ -35,16 +37,15 @@ public class ApplicationController {
     }
 
     @GetMapping("/application")
-    public SingleApplicationRes readMe(@AuthenticationPrincipal UserInfo userInfo) {
-        return querySingleApplicationService.execute(userInfo.getUserId());
+    public SingleApplicationRes readMe() {
+        return querySingleApplicationService.execute(manager.getId());
     }
 
     @PostMapping("/application")
     public ResponseEntity<Map<String, String>> create(
-            @RequestBody @Valid ApplicationReqDto body,
-            @AuthenticationPrincipal UserInfo userInfo
+            @RequestBody @Valid ApplicationReqDto body
     ) {
-        createApplicationService.execute(body, userInfo.getUserId());
+        createApplicationService.execute(body, manager.getId());
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("message", "생성되었습니다"));
     }
 
@@ -53,7 +54,7 @@ public class ApplicationController {
             @RequestBody @Valid ApplicationReqDto body,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
-        modifyApplicationService.execute(body, userInfo.getUserId());
+        modifyApplicationService.execute(body, manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "수정되었습니다"));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -11,6 +11,7 @@ import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
 import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
+import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 import team.themoment.hellogsm.web.global.security.oauth.UserInfo;
 
 import java.net.URI;
@@ -20,7 +21,7 @@ import java.net.URISyntaxException;
 @RequestMapping("/identity/v1")
 @RequiredArgsConstructor
 public class IdentityController {
-
+    private final AuthenticatedUserManager manager;
     private final CreateIdentityService createIdentityService;
     private final IdentityQuery identityQuery;
 
@@ -38,10 +39,9 @@ public class IdentityController {
 
     @PostMapping("/identity")
     public ResponseEntity<Object> create(
-            @RequestBody @Valid CreateIdentityReqDto userDto,
-            @AuthenticationPrincipal UserInfo userInfo
+            @RequestBody @Valid CreateIdentityReqDto userDto
     ) {
-        createIdentityService.execute(userDto, userInfo.getUserId());
+        createIdentityService.execute(userDto, manager.getId());
         URI redirectUri = null;
         try {
             redirectUri = new URI("/auth/v1/logout");
@@ -54,10 +54,8 @@ public class IdentityController {
     }
 
     @GetMapping("/identity")
-    public ResponseEntity<IdentityDto> find(
-            @AuthenticationPrincipal UserInfo userInfo
-    ) {
-        IdentityDto identityResDto = identityQuery.execute(userInfo.getUserId());
+    public ResponseEntity<IdentityDto> find() {
+        IdentityDto identityResDto = identityQuery.execute(manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(identityResDto);
     }
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/controller/UserController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/controller/UserController.java
@@ -3,27 +3,24 @@ package team.themoment.hellogsm.web.domain.user.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team.themoment.hellogsm.web.domain.user.dto.domain.UserDto;
 import team.themoment.hellogsm.web.domain.user.service.UserByIdQuery;
-import team.themoment.hellogsm.web.global.security.oauth.UserInfo;
+import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 @RestController
 @RequestMapping("/user/v1")
 @RequiredArgsConstructor
 public class UserController {
-
+    private final AuthenticatedUserManager manager;
     private final UserByIdQuery userByIdQuery;
 
     @GetMapping("/user")
-    public ResponseEntity<UserDto> find(
-            @AuthenticationPrincipal UserInfo userInfo
-    ) {
-        UserDto userDto = userByIdQuery.execute(userInfo.getUserId());
+    public ResponseEntity<UserDto> find() {
+        UserDto userDto = userByIdQuery.execute(manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(userDto);
     }
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManager.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManager.java
@@ -1,0 +1,11 @@
+package team.themoment.hellogsm.web.global.security.auth;
+
+import team.themoment.hellogsm.entity.domain.user.enums.Role;
+
+import java.time.LocalDateTime;
+
+public interface AuthenticatedUserManager {
+    Long getId();
+    Role getRole();
+    LocalDateTime getLastLoginTime();
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManagerImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManagerImpl.java
@@ -1,0 +1,30 @@
+package team.themoment.hellogsm.web.global.security.auth;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+import team.themoment.hellogsm.entity.domain.user.enums.Role;
+
+import java.time.LocalDateTime;
+
+@Component
+public class AuthenticatedUserManagerImpl implements AuthenticatedUserManager {
+    @Override
+    public Long getId() {
+        OAuth2User oAuth2User = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return Long.valueOf(oAuth2User.getName());
+    }
+
+    @Override
+    public Role getRole() {
+        OAuth2User oAuth2User = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return oAuth2User.getAttribute("role");
+    }
+
+    @Override
+    public LocalDateTime getLastLoginTime() {
+        OAuth2User oAuth2User =
+                (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return oAuth2User.getAttribute("last_login_time");
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/oauth/UserInfo.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/oauth/UserInfo.java
@@ -1,59 +1,32 @@
 package team.themoment.hellogsm.web.global.security.oauth;
 
-import team.themoment.hellogsm.entity.domain.user.entity.User;
-import team.themoment.hellogsm.entity.domain.user.enums.Role;
-import team.themoment.hellogsm.web.domain.user.dto.domain.UserDto;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 
 import java.io.Serializable;
-import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
-public class UserInfo implements OAuth2User, Serializable {
-    private final Long userId;
-    private final Role userRole;
-    private final String userName;
-    private final LocalDateTime lastLoginTime;
+public class UserInfo extends DefaultOAuth2User implements Serializable {
 
-    public UserInfo(User user, LocalDateTime lastLoginTime) {
-        this.userId = user.getId();
-        this.userRole = user.getRole();
-        this.userName = user.getProvider() + "_" + user.getProviderId();
-        this.lastLoginTime = lastLoginTime;
+    private static final long serialVersionUID = 123456789L;
+    
+    public UserInfo(Collection<? extends GrantedAuthority> authorities, Map<String, Object> attributes, String nameAttributeKey) {
+        super(authorities, attributes, nameAttributeKey);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return super.getAttributes();
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(userRole.name()));
-    }
-
-    public Role getUserRole() {
-        return userRole;
-    }
-
-    public Long getUserId() {
-        return userId;
-    }
-
-    public LocalDateTime getLastLoginTime() {
-        return lastLoginTime;
+        return super.getAuthorities();
     }
 
     @Override
     public String getName() {
-        return userName;
-    }
-
-    /**
-     * @deprecated 해당 메서드는 사용하지 않습니다.
-     */
-    @Override
-    @Deprecated(forRemoval = true)
-    public Map<String, Object> getAttributes() {
-        throw new IllegalStateException("해당 메서드는 사용하지 않습니다.");
+        return super.getName();
     }
 }


### PR DESCRIPTION
## 개요

UserInfo와 CustomOauth2UserService를 리팩토링하였습니다.
모든 Controller에서 `@AuthenticationPrincipal`를 사용하지 않도록 변경하였습니다.

## 본문

UserInfo 클래스를 OAuth2User의 명세에 맞도록 설계를 변경하였습니다.
모든 Controller에서 인증된 사용자 정보를 가져오는 `AuthenticatedUserManager` 인터페이스를 DI 받아 사용하도록 변경하였습니다.

### 추가 

- `AuthenticatedUserManager` : 인증된 사용자 정보를 가져오는 인터페이스를 구현하였습니다.
- `AuthenticatedUserManagerImlp` :  `Authentication`에서 인증된 유저 정보를 반환하는 `AuthenticatedUserManager` 구현체를 구현하였습니다.

### 변경 

- `UserInfo` :  `OAuth2User` 인터페이스의 명세에 맞도록 설계를 변경하였습니다.
- `CustomOauth2UserService`: 필요하지 않은 메서드를 제거하고, `UserInfo`가 변경됨에 따라 일부 코드가 함께 변경되었습니다.
- 모든 Controller : `@AuthenticationPrincipal` 대신 `AuthenticatedUserManager`를 사용하도록 대체하였습니다.

