### PR TITLE
사용하지 않는 userInfo 파라미터 제거 및 import 제거

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -7,11 +7,9 @@ import team.themoment.hellogsm.web.domain.application.service.CreateApplicationS
 import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationService;
 import team.themoment.hellogsm.web.domain.application.service.QuerySingleApplicationService;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
-import team.themoment.hellogsm.web.global.security.oauth.UserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -51,8 +49,7 @@ public class ApplicationController {
 
     @PutMapping("/application")
     public ResponseEntity<Map<String, String>> modify(
-            @RequestBody @Valid ApplicationReqDto body,
-            @AuthenticationPrincipal UserInfo userInfo
+            @RequestBody @Valid ApplicationReqDto body
     ) {
         modifyApplicationService.execute(body, manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "수정되었습니다"));

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -5,14 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
 import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
-import team.themoment.hellogsm.web.global.security.oauth.UserInfo;
 
 import java.net.URI;
 import java.net.URISyntaxException;


### PR DESCRIPTION
## 개요

`ApplicationController`에서 삭제가 누락된 @AuthenticationPrincipal 를 제거하였습니다.
의존성을 가지지 않는 AuthenticationPrincipal, UserInfo에 대한 import를 제거하였습니다.