### PR TITLE
Controllers 인증된 유저 정보를 사용하는 URI 수정

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -34,12 +34,12 @@ public class ApplicationController {
         return querySingleApplicationService.execute(applicationId);
     }
 
-    @GetMapping("/application")
+    @GetMapping("/application/me")
     public SingleApplicationRes readMe() {
         return querySingleApplicationService.execute(manager.getId());
     }
 
-    @PostMapping("/application")
+    @PostMapping("/application/me")
     public ResponseEntity<Map<String, String>> create(
             @RequestBody @Valid ApplicationReqDto body
     ) {
@@ -47,7 +47,7 @@ public class ApplicationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("message", "생성되었습니다"));
     }
 
-    @PutMapping("/application")
+    @PutMapping("/application/me")
     public ResponseEntity<Map<String, String>> modify(
             @RequestBody @Valid ApplicationReqDto body
     ) {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -35,7 +35,7 @@ public class IdentityController {
         return ResponseEntity.status(HttpStatus.CREATED).body(identityResDto);
     }
 
-    @PostMapping("/identity")
+    @PostMapping("/identity/me")
     public ResponseEntity<Object> create(
             @RequestBody @Valid CreateIdentityReqDto userDto
     ) {
@@ -51,7 +51,7 @@ public class IdentityController {
         return new ResponseEntity<>(httpHeaders, HttpStatus.SEE_OTHER);
     }
 
-    @GetMapping("/identity")
+    @GetMapping("/identity/me")
     public ResponseEntity<IdentityDto> find() {
         IdentityDto identityResDto = identityQuery.execute(manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(identityResDto);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/controller/UserController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/controller/UserController.java
@@ -18,7 +18,7 @@ public class UserController {
     private final AuthenticatedUserManager manager;
     private final UserByIdQuery userByIdQuery;
 
-    @GetMapping("/user")
+    @GetMapping("/user/me")
     public ResponseEntity<UserDto> find() {
         UserDto userDto = userByIdQuery.execute(manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(userDto);


### PR DESCRIPTION
## 개요

인증된 유저 정보를 사용하는 메서드의 Mapping URI를 `{생략}/도매안이름` 에서 `{생략}/도매안이름/me`로 변경하였습니다.

## 본문

UserController, IdentityController, ApplicationController의 Mapping URI를 변경하였습니다.
