### PR TITLE
IdentityController 오타 수정

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -57,11 +57,11 @@ public class IdentityController {
         return ResponseEntity.status(HttpStatus.OK).body(identityResDto);
     }
 
-    @GetMapping("/identity/{identityId}")
+    @GetMapping("/identity/{userId}")
     public ResponseEntity<IdentityDto> findByIdentityId(
-            @PathVariable Long identityId
+            @PathVariable Long userId
     ) {
-        IdentityDto identityResDto = identityQuery.execute(identityId);
+        IdentityDto identityResDto = identityQuery.execute(userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(identityResDto);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -58,7 +58,7 @@ public class IdentityController {
     }
 
     @GetMapping("/identity/{userId}")
-    public ResponseEntity<IdentityDto> findByIdentityId(
+    public ResponseEntity<IdentityDto> findByUserId(
             @PathVariable Long userId
     ) {
         IdentityDto identityResDto = identityQuery.execute(userId);


### PR DESCRIPTION
## 개요

`IdentityController#findByIdentityId()` 메서드 이름이 잘못되어 수정하였습니다.
- 메서드 명 수정 `IdentityController#findByIdentityId()` -> `IdentityController#findByUserId()`
- `IdentityController#findByIdentityId()` 잘못된 파라미터 이름 변경 `identityId` -> `userId`