### PR TITLE
IdentityControllerTest 추가 및 API 작성,보완

### DIFF
--- a/hellogsm-web/src/docs/asciidoc/index.adoc
+++ b/hellogsm-web/src/docs/asciidoc/index.adoc
@@ -98,18 +98,52 @@ ID로 USER를 조회합니다.
 WARNING: `userId` 를 입력해야만 합니다.
 
 ==== Request
-operation::find-by-user-id[snippets='curl-request,httpie-request,http-request,path-parameters']
+operation::user/find-by-user-id[snippets='curl-request,httpie-request,http-request,path-parameters']
 
 ==== Response
-operation::find-by-user-id[snippets='http-response,response-fields']
+operation::user/find-by-user-id[snippets='http-response,response-fields']
 
 === 인증된 USER 조회
 현재 인증되어있는 회원을 조회합니다.
 
 ==== Request
-operation::find-by-authenticated[snippets='curl-request,httpie-request,http-request,request-headers']
+operation::user/find-by-authenticated[snippets='curl-request,httpie-request,http-request,request-headers']
 
 ==== Response
-operation::find-by-authenticated[snippets='http-response,response-fields']
+operation::user/find-by-authenticated[snippets='http-response,response-fields']
 
+== 신원(Identity)
+회원의 본인인증 정보(실명, 전화번호)를 생성,조회 할 수 있습니다.
 
+=== ID로 IDENTITY 조회
+ID로  IDENTITY를 조회합니다.
+
+WARNING: `userId` 를 입력해야만 합니다.
+
+==== Request
+operation::identity/find-by-user-id[snippets='curl-request,httpie-request,http-request,path-parameters']
+
+==== Response
+operation::identity/find-by-user-id[snippets='http-response,response-fields']
+
+=== 인증 중인 정보로 IDENTITY 조회
+현재 인증되어있는 사용자 정보로 신원을 조회합니다.
+
+==== Request
+operation::identity/find-by-authenticated[snippets='curl-request,httpie-request,http-request,request-headers']
+
+==== Response
+operation::identity/find-by-authenticated[snippets='http-response,response-fields']
+
+=== 인증 중인 정보로 IDENTITY 생성
+현재 인증되어있는 사용자 정보로 신원을 생성합니다.
+
+사용자의 개인정보(본인인증 정보)를 등록하고 권한을 `인증된 유저(ROLE_USER)` 로 변경합니다.
+
+==== Request
+operation::identity/create-by-authenticated[snippets='curl-request,httpie-request,http-request,request-body']
+
+==== Response
+사용자의 권한이 업데이트되어 세션 정보를 갱신하기 위해 로그아웃 URI로 리다이렉트됩니다.
+
+operation::identity/create-by-authenticated[snippets='http-response']

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
@@ -1,0 +1,150 @@
+package team.themoment.hellogsm.web.domain.identity.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import team.themoment.hellogsm.entity.domain.user.enums.Role;
+import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
+import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
+import team.themoment.hellogsm.web.domain.user.dto.domain.UserDto;
+import team.themoment.hellogsm.web.domain.user.service.UserByIdQuery;
+import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ExtendWith(RestDocumentationExtension.class)
+class IdentityControllerTest {
+
+    private RestDocumentationResultHandler documentationHandler;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthenticatedUserManager manager;
+
+    @MockBean
+    private CreateIdentityService createIdentityService;
+
+    @MockBean
+    private IdentityQuery identityQuery;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.documentationHandler = document("identity/{method-name}",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()));
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context)
+                .apply(documentationConfiguration(restDocumentation))
+                .alwaysDo(this.documentationHandler)
+                .build();
+    }
+
+
+    protected final FieldDescriptor[] identityResponseFields = new FieldDescriptor[]{
+            fieldWithPath("id").type(NUMBER).description("IDENTITY 식별자"),
+            fieldWithPath("name").type(STRING).description("USER의 이름"),
+            fieldWithPath("phoneNumber").type(STRING).description("USER의 휴대전화 번호"),
+            fieldWithPath("userId").type(NUMBER).description("USER 식별자")
+    };
+
+    @Test
+    @DisplayName("인증된 유저 정보로 IDENTITY 조회")
+    void findByAuthenticated() throws Exception {
+        Long userId = 1L;
+        IdentityDto identity = new IdentityDto(1L, "홍길동", "01012345678", userId);
+        Mockito.when(identityQuery.execute(any(Long.class))).thenReturn(identity);
+
+        this.mockMvc.perform(get("/identity/v1/identity/me")
+                    .cookie(new Cookie("SESSION", "SESSIONID12345")))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(identity.id()))
+                .andExpect(jsonPath("$.name").value(identity.name()))
+                .andExpect(jsonPath("$.phoneNumber").value(identity.phoneNumber()))
+                .andExpect(jsonPath("$.userId").value(identity.userId()))
+                .andDo(this.documentationHandler.document(
+                        requestHeaders(headerWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                        responseFields(identityResponseFields)
+                ));
+    }
+
+    @Test
+    @DisplayName("USER ID로 IDENTITY 조회")
+    void findByUserId() throws Exception {
+        Long userId = 1L;
+        IdentityDto identity = new IdentityDto(1L, "홍길동", "01012345678", userId);
+        Mockito.when(identityQuery.execute(any(Long.class))).thenReturn(identity);
+        Mockito.when(manager.getId()).thenReturn(userId);
+
+        this.mockMvc.perform(get("/identity/v1/identity/{userId}", userId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(identity.id()))
+                .andExpect(jsonPath("$.name").value(identity.name()))
+                .andExpect(jsonPath("$.phoneNumber").value(identity.phoneNumber()))
+                .andExpect(jsonPath("$.userId").value(identity.userId()))
+                .andDo(this.documentationHandler.document(
+                        pathParameters(parameterWithName("userId").description("조회하고자 하는 USER의 식별자")),
+                        responseFields(identityResponseFields)
+                ));
+    }
+
+    @Test
+    @DisplayName("인증된 유저 정보로 IDENTITY 생성")
+    void createByAuthenticated() throws Exception {
+        Long userId = 1L;
+        CreateIdentityReqDto request = new CreateIdentityReqDto("홍길동", "01012345678");
+        IdentityDto identity = new IdentityDto(1L, "홍길동", "01012345678", userId);
+        Mockito.when(createIdentityService.execute(any(CreateIdentityReqDto.class), any(Long.class))).thenReturn(identity);
+        Mockito.when(manager.getId()).thenReturn(userId);
+
+        this.mockMvc.perform(post("/identity/v1/identity/me", userId, MediaType.APPLICATION_JSON)
+                        .cookie(new Cookie("SESSION", "SESSIONID12345"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(this.objectMapper.writeValueAsString(request)))
+                .andExpect(status().isSeeOther())
+                .andDo(print());
+    }
+}

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
@@ -32,6 +32,8 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -105,7 +107,7 @@ class IdentityControllerTest {
                 .andExpect(jsonPath("$.phoneNumber").value(identity.phoneNumber()))
                 .andExpect(jsonPath("$.userId").value(identity.userId()))
                 .andDo(this.documentationHandler.document(
-                        requestHeaders(headerWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
                         responseFields(identityResponseFields)
                 ));
     }
@@ -145,6 +147,8 @@ class IdentityControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(this.objectMapper.writeValueAsString(request)))
                 .andExpect(status().isSeeOther())
-                .andDo(print());
+                .andDo(this.documentationHandler.document(
+                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다."))
+                ));
     }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
@@ -23,7 +23,8 @@ import team.themoment.hellogsm.web.domain.user.service.UserByIdQuery;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
@@ -90,7 +91,7 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.providerId").value(user.providerId()))
                 .andExpect(jsonPath("$.role").value(user.role().name()))
                 .andDo(this.documentationHandler.document(
-                        requestHeaders(headerWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
                         responseFields(userResponseFields)
                 ));
     }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.user.controller;
 
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -81,7 +82,7 @@ class UserControllerTest {
         Mockito.when(manager.getId()).thenReturn(id);
 
         this.mockMvc.perform(get("/user/v1/user/me")
-                        .header("SESSION", "SESSIONID12345"))
+                        .cookie(new Cookie("SESSION", "SESSIONID12345")))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").value(user.id()))


### PR DESCRIPTION
## 개요

IdentityController 테스트코드를 추가하였습니다.
API 명세서(index.adoc)에 Identity 관련 내용을 추가하고, 일부 다른 도메인 부분을 보완하였습니다.


## 본문

### 추가

- IdentityController 테스트코드 추가

### 변경 - optional

- UserControllerTest 코드 변경
  - 세션 쿠키 대신 헤더로 등록하던 문제 해결
- API 명세서에 Identity 관련 문서 추가 작성

