### PR TITLE
Rest Docs 관련 Test만 실행하는 Gradle Task 추가

### DIFF
--- a/hellogsm-web/build.gradle
+++ b/hellogsm-web/build.gradle
@@ -45,11 +45,11 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 }
 
-
-tasks.named('test').configure {
-    actions.clear() // root에서 시행한 task를 clear
+task restDocsTest(type: Test) {
     outputs.dir snippetsDir
-    useJUnitPlatform()
+    useJUnitPlatform {
+            includeTags 'restDocsTest'
+    }
 }
 
 tasks.named('asciidoctor') {

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -48,6 +49,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@Tag("restDocsTest")
 @SpringBootTest
 @ExtendWith(RestDocumentationExtension.class)
 class IdentityControllerTest {

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsm.web.domain.user.controller;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -37,6 +38,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@Tag("restDocsTest")
 @SpringBootTest
 @ExtendWith(RestDocumentationExtension.class)
 class UserControllerTest {


### PR DESCRIPTION
## 개요

일반적인 test task 실행 시 Rest Docs 관련 파일(.adoc)이 사용되지 않는 문제를 해결하기 위해


## 본문

rest docs 생성을 위해선 기존 테스트보다 먼저 테스트 결과를 저장하도록 설정해야 하는데, 우리 프로젝트의 경우 test task를 root 모듈에서 관리하고 있어 #77 과 같은 문제가 발생하였습니다.

해결하기 위해 2가지 방안을 고려하였습니다. 
1. root의 task를 재정의 하기
2. rest docs 관련 테스트만 실행하는 task를 새로 정의하기

기존에 1번 방식으로 구현하였지만, 정상적으로 작동하지 않아 2번 방식인 `@Tag` 를 사용해 rest docs 관련 테스트만 실행하는 task를 추가하였습니다. 
해당 task를 사용하여 gradle 명령어로도 restdocs 관련 파일을 생성할 수 있습니다.
