### PR TITLE
[#65] 적절하지 않은 파라미터 이름 수정

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -29,9 +29,9 @@ public class ApplicationController {
     private final ModifyApplicationService modifyApplicationService;
     private final QuerySingleApplicationService querySingleApplicationService;
 
-    @GetMapping("/application/{applicationId}")
-    public SingleApplicationRes readOne(@PathVariable("applicationId") Long applicationId) {
-        return querySingleApplicationService.execute(applicationId);
+    @GetMapping("/application/{userId}")
+    public SingleApplicationRes readOne(@PathVariable("userId") Long userId) {
+        return querySingleApplicationService.execute(userId);
     }
 
     @GetMapping("/application/me")

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/QuerySingleApplicationService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/QuerySingleApplicationService.java
@@ -3,5 +3,5 @@ package team.themoment.hellogsm.web.domain.application.service;
 import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplicationRes;
 
 public interface QuerySingleApplicationService {
-    SingleApplicationRes execute(Long applicantId);
+    SingleApplicationRes execute(Long userId);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/QuerySingleApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/QuerySingleApplicationServiceImpl.java
@@ -16,8 +16,8 @@ public class QuerySingleApplicationServiceImpl implements QuerySingleApplication
     final private ApplicationRepository applicationRepository;
 
     @Override
-    public SingleApplicationRes execute(Long applicationId) {
-        Application application = applicationRepository.findByUserIdEagerFetch(applicationId)
+    public SingleApplicationRes execute(Long userId) {
+        Application application = applicationRepository.findByUserIdEagerFetch(userId)
                 .orElseThrow(() -> new ExpectedException("존재하지 않는 유저입니다", HttpStatus.NOT_FOUND));
 
         return ApplicationMapper.INSTANCE.createSingleApplicationDto(application);


### PR DESCRIPTION
## 개요

application 부분에 readOne 메서드와 `QuerySingleApplicationService`의 파라미터 이름을 applicationId로 했습니다
하지만 `QuerySingleApplicationServiceImpl`에서는 userId를 통해 원서를 찾기 때문에 적절하지 않은 이름이라 생각이 들었습니다

## 본문

controller와 service의 `applicationId`를 `userId`로 변경했습니다