### PR TITLE
[#10] 원서 삭제 기능 추가

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplicationRes;
 import team.themoment.hellogsm.web.domain.application.service.CreateApplicationService;
+import team.themoment.hellogsm.web.domain.application.service.DeleteApplicationService;
 import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationService;
 import team.themoment.hellogsm.web.domain.application.service.QuerySingleApplicationService;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
@@ -28,6 +29,7 @@ public class ApplicationController {
     private final CreateApplicationService createApplicationService;
     private final ModifyApplicationService modifyApplicationService;
     private final QuerySingleApplicationService querySingleApplicationService;
+    private final DeleteApplicationService deleteApplicationService;
 
     @GetMapping("/application/{applicationId}")
     public SingleApplicationRes readOne(@PathVariable("applicationId") Long applicationId) {
@@ -53,5 +55,11 @@ public class ApplicationController {
     ) {
         modifyApplicationService.execute(body, manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "수정되었습니다"));
+    }
+
+    @DeleteMapping("/application/me")
+    public ResponseEntity<Map<String, String>> delete() {
+        deleteApplicationService.execute(manager.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "삭제되었습니다"));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
@@ -18,4 +18,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     @Query("select a from Application a join fetch a.admissionGrade join fetch a.admissionInfo join fetch a.admissionStatus join fetch a.middleSchoolGrade")
     Optional<Application> findByUserIdEagerFetch(Long userId);
+
+    void deleteApplicationByUserId(Long userId);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/DeleteApplicationService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/DeleteApplicationService.java
@@ -1,0 +1,5 @@
+package team.themoment.hellogsm.web.domain.application.service;
+
+public interface DeleteApplicationService {
+    void execute(Long userId);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.java
@@ -8,11 +8,11 @@ import team.themoment.hellogsm.web.domain.application.service.DeleteApplicationS
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class DeleteApplicationServiceImpl implements DeleteApplicationService {
     private final ApplicationRepository applicationRepository;
 
     @Override
-    @Transactional
     public void execute(Long userId) {
         applicationRepository.deleteApplicationByUserId(userId);
     }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.java
@@ -8,7 +8,7 @@ import team.themoment.hellogsm.web.domain.application.service.DeleteApplicationS
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(rollbackFor = {Exception.class})
 public class DeleteApplicationServiceImpl implements DeleteApplicationService {
     private final ApplicationRepository applicationRepository;
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.java
@@ -1,0 +1,19 @@
+package team.themoment.hellogsm.web.domain.application.service.impl;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
+import team.themoment.hellogsm.web.domain.application.service.DeleteApplicationService;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteApplicationServiceImpl implements DeleteApplicationService {
+    private final ApplicationRepository applicationRepository;
+
+    @Override
+    @Transactional
+    public void execute(Long userId) {
+        applicationRepository.deleteApplicationByUserId(userId);
+    }
+}


### PR DESCRIPTION
## 개요

원서를 삭제하는 기능을 추가했습니다

## 본문

`/application/me`에 delete 메서드로 요처을 날리면 자신의 원서를 삭제하는 기능을 추가했습니다

### 추가

- controller에 delete 메서드를 추가했습니다
- ApplicationRepository에 `deleteApplicationByUserId` 메서드를 추가했습니다
- 원서를 삭제하는 service를 추가했습니다