### PR TITLE
[#6] 모든 원서를 조회하는 기능을 추가했습니다

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -8,6 +8,7 @@ import team.themoment.hellogsm.web.domain.application.service.ApplicationListQue
 import team.themoment.hellogsm.web.domain.application.service.CreateApplicationService;
 import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationService;
 import team.themoment.hellogsm.web.domain.application.service.QuerySingleApplicationService;
+import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -59,7 +60,12 @@ public class ApplicationController {
     }
 
     @GetMapping("/application/all")
-    public ApplicationListDto findAll() {
-        return applicationListQuery.execute();
+    public ApplicationListDto findAll(
+            @RequestParam("page") int page,
+            @RequestParam("size") int size
+    ) {
+        if (page < 1 || size < 1)
+            throw new ExpectedException("1이상만 가능합니다", HttpStatus.BAD_REQUEST);
+        return applicationListQuery.execute(page, size);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -2,7 +2,9 @@ package team.themoment.hellogsm.web.domain.application.controller;
 
 import jakarta.validation.Valid;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplicationRes;
+import team.themoment.hellogsm.web.domain.application.service.ApplicationListQuery;
 import team.themoment.hellogsm.web.domain.application.service.CreateApplicationService;
 import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationService;
 import team.themoment.hellogsm.web.domain.application.service.QuerySingleApplicationService;
@@ -28,6 +30,7 @@ public class ApplicationController {
     private final CreateApplicationService createApplicationService;
     private final ModifyApplicationService modifyApplicationService;
     private final QuerySingleApplicationService querySingleApplicationService;
+    private final ApplicationListQuery applicationListQuery;
 
     @GetMapping("/application/{applicationId}")
     public SingleApplicationRes readOne(@PathVariable("applicationId") Long applicationId) {
@@ -53,5 +56,10 @@ public class ApplicationController {
     ) {
         modifyApplicationService.execute(body, manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "수정되었습니다"));
+    }
+
+    @GetMapping("/application/all")
+    public ApplicationListDto findAll() {
+        return applicationListQuery.execute();
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -66,8 +66,8 @@ public class ApplicationController {
 
     @GetMapping("/application/all")
     public ApplicationListDto findAll(
-            @RequestParam("page") int page,
-            @RequestParam("size") int size
+            @RequestParam("page") Integer page,
+            @RequestParam("size") Integer size
     ) {
         if (page < 0 || size < 0)
             throw new ExpectedException("0 이상만 가능합니다", HttpStatus.BAD_REQUEST);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -69,8 +69,8 @@ public class ApplicationController {
             @RequestParam("page") int page,
             @RequestParam("size") int size
     ) {
-        if (page < 1 || size < 1)
-            throw new ExpectedException("1이상만 가능합니다", HttpStatus.BAD_REQUEST);
+        if (page < 0 || size < 0)
+            throw new ExpectedException("0 이상만 가능합니다", HttpStatus.BAD_REQUEST);
         return applicationListQuery.execute(page, size);
     }
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationListDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationListDto.java
@@ -1,0 +1,9 @@
+package team.themoment.hellogsm.web.domain.application.dto.response;
+
+import java.util.List;
+
+public record ApplicationListDto(
+        ApplicationListInfoDto info,
+        List<ApplicationsDto> applications
+) {
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationListInfoDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationListInfoDto.java
@@ -1,0 +1,5 @@
+package team.themoment.hellogsm.web.domain.application.dto.response;
+
+public record ApplicationListInfoDto (
+        Integer count
+) {}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationsDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationsDto.java
@@ -1,0 +1,21 @@
+package team.themoment.hellogsm.web.domain.application.dto.response;
+
+import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
+import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
+
+public record ApplicationsDto(
+        Long applicationId,
+        String applicantName,
+        GraduationStatus graduation,
+        String applicantPhoneNumber,
+        String guardianPhoneNumber,
+        String teacherName,
+        String teacherPhoneNumber,
+        Boolean isFinalSubmitted,
+        Boolean isPrintsArrived,
+        EvaluationStatus firstEvaluation,
+        EvaluationStatus secondEvaluation,
+        Long registrationNumber,
+        String secondScore
+) {
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -9,7 +9,12 @@ import team.themoment.hellogsm.entity.domain.application.entity.grade.GraduateAd
 import team.themoment.hellogsm.entity.domain.application.entity.status.AdmissionStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
 import team.themoment.hellogsm.web.domain.application.dto.domain.*;
+import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
+import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListInfoDto;
+import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationsDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplicationRes;
+
+import java.util.List;
 
 @Mapper(
         componentModel = "spring",
@@ -104,4 +109,28 @@ public interface ApplicationMapper {
             @Mapping(source = "finalMajor", target = "finalMajor"),
     })
     AdmissionStatusDto admissionStatusToAdmissionStatusDto(AdmissionStatus admissionStatus);
+
+    default ApplicationListDto createApplicationListDto(List<Application> applicationList) {
+        return new ApplicationListDto(new ApplicationListInfoDto(applicationList.size()), applicationListToApplicationsDtoList(applicationList));
+    }
+
+    @BeanMapping(ignoreUnmappedSourceProperties = {"middleSchoolGrade", "admissionGrade", "userId"})
+    @Mappings({
+            @Mapping(source = "id", target = "applicationId"),
+            @Mapping(source = "admissionInfo.applicantName", target = "applicantName"),
+            @Mapping(source = "admissionInfo.graduation", target = "graduation"),
+            @Mapping(source = "admissionInfo.applicantPhoneNumber", target = "applicantPhoneNumber"),
+            @Mapping(source = "admissionInfo.guardianPhoneNumber", target = "guardianPhoneNumber"),
+            @Mapping(source = "admissionInfo.teacherName", target = "teacherName"),
+            @Mapping(source = "admissionInfo.teacherPhoneNumber", target = "teacherPhoneNumber"),
+            @Mapping(source = "admissionStatus.isFinalSubmitted", target = "isFinalSubmitted"),
+            @Mapping(source = "admissionStatus.isPrintsArrived", target = "isPrintsArrived"),
+            @Mapping(source = "admissionStatus.firstEvaluation", target = "firstEvaluation"),
+            @Mapping(source = "admissionStatus.secondEvaluation", target = "secondEvaluation"),
+            @Mapping(source = "admissionStatus.registrationNumber", target = "registrationNumber"),
+            @Mapping(source = "admissionStatus.secondScore", target = "secondScore"),
+    })
+    ApplicationsDto applicationToApplicationsDto(Application applicationList);
+
+    List<ApplicationsDto> applicationListToApplicationsDtoList(List<Application> applicationList);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -111,7 +111,10 @@ public interface ApplicationMapper {
     AdmissionStatusDto admissionStatusToAdmissionStatusDto(AdmissionStatus admissionStatus);
 
     default ApplicationListDto createApplicationListDto(List<Application> applicationList) {
-        return new ApplicationListDto(new ApplicationListInfoDto(applicationList.size()), applicationListToApplicationsDtoList(applicationList));
+        return new ApplicationListDto(
+                new ApplicationListInfoDto(applicationList.size()),
+                applicationListToApplicationsDtoList(applicationList)
+        );
     }
 
     @BeanMapping(ignoreUnmappedSourceProperties = {"middleSchoolGrade", "admissionGrade", "userId"})

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -18,4 +19,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     @Query("select a from Application a join fetch a.admissionGrade join fetch a.admissionInfo join fetch a.admissionStatus join fetch a.middleSchoolGrade")
     Optional<Application> findByUserIdEagerFetch(Long userId);
+
+    @Query("select a from Application a join fetch a.admissionGrade join fetch a.admissionInfo join fetch a.admissionStatus join fetch a.middleSchoolGrade")
+    List<Application> findAllEagerFetch();
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
@@ -1,5 +1,7 @@
 package team.themoment.hellogsm.web.domain.application.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
@@ -20,6 +22,5 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     @Query("select a from Application a join fetch a.admissionGrade join fetch a.admissionInfo join fetch a.admissionStatus join fetch a.middleSchoolGrade")
     Optional<Application> findByUserIdEagerFetch(Long userId);
 
-    @Query("select a from Application a join fetch a.admissionInfo join fetch a.admissionStatus")
-    List<Application> findAllEagerFetch();
+    Page<Application> findAll(Pageable pageable);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
@@ -20,6 +20,6 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     @Query("select a from Application a join fetch a.admissionGrade join fetch a.admissionInfo join fetch a.admissionStatus join fetch a.middleSchoolGrade")
     Optional<Application> findByUserIdEagerFetch(Long userId);
 
-    @Query("select a from Application a join fetch a.admissionGrade join fetch a.admissionInfo join fetch a.admissionStatus join fetch a.middleSchoolGrade")
+    @Query("select a from Application a join fetch a.admissionInfo join fetch a.admissionStatus")
     List<Application> findAllEagerFetch();
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ApplicationListQuery.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ApplicationListQuery.java
@@ -1,0 +1,7 @@
+package team.themoment.hellogsm.web.domain.application.service;
+
+import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
+
+public interface ApplicationListQuery {
+    ApplicationListDto execute();
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ApplicationListQuery.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ApplicationListQuery.java
@@ -3,5 +3,5 @@ package team.themoment.hellogsm.web.domain.application.service;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
 
 public interface ApplicationListQuery {
-    ApplicationListDto execute();
+    ApplicationListDto execute(Integer page, Integer size);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ApplicationListQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ApplicationListQueryImpl.java
@@ -1,6 +1,10 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
@@ -8,16 +12,15 @@ import team.themoment.hellogsm.web.domain.application.mapper.ApplicationMapper;
 import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
 import team.themoment.hellogsm.web.domain.application.service.ApplicationListQuery;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class ApplicationListQueryImpl implements ApplicationListQuery {
     final ApplicationRepository applicationRepository;
 
     @Override
-    public ApplicationListDto execute() {
-        List<Application> applicationList = applicationRepository.findAll();
-        return ApplicationMapper.INSTANCE.createApplicationListDto(applicationList);
+    public ApplicationListDto execute(Integer page, Integer size) {
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
+        Page<Application> applicationPage = applicationRepository.findAll(pageable);
+        return ApplicationMapper.INSTANCE.createApplicationListDto(applicationPage.getContent());
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ApplicationListQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ApplicationListQueryImpl.java
@@ -19,7 +19,7 @@ public class ApplicationListQueryImpl implements ApplicationListQuery {
 
     @Override
     public ApplicationListDto execute(Integer page, Integer size) {
-        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "id"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
         Page<Application> applicationPage = applicationRepository.findAll(pageable);
         return ApplicationMapper.INSTANCE.createApplicationListDto(applicationPage.getContent());
     }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ApplicationListQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ApplicationListQueryImpl.java
@@ -1,0 +1,23 @@
+package team.themoment.hellogsm.web.domain.application.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsm.entity.domain.application.entity.Application;
+import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
+import team.themoment.hellogsm.web.domain.application.mapper.ApplicationMapper;
+import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
+import team.themoment.hellogsm.web.domain.application.service.ApplicationListQuery;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationListQueryImpl implements ApplicationListQuery {
+    final ApplicationRepository applicationRepository;
+
+    @Override
+    public ApplicationListDto execute() {
+        List<Application> applicationList = applicationRepository.findAll();
+        return ApplicationMapper.INSTANCE.createApplicationListDto(applicationList);
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.java
@@ -1,8 +1,8 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
 import team.themoment.hellogsm.web.domain.application.service.DeleteApplicationService;
 


### PR DESCRIPTION
## 개요

모든 원서를 조회하는 기능을 추가했습니다
원서 내용은 노션에 있는 Response값과 똑같이 했습니다

## 본문

- 모든 원서를 조회하기 위해 dto, service, controller를 추가했습니다

### 피드백

Responser값은 대충 아래와 같습니다

```json
{
	"info": {
		"count": Long, - 실물원서까지 제출한 유저의 수
	},
  "applications": []
}
```

이런 형식 때문에 applications 부분의 클래스 이름을 `ApplicationsDto`라고 했고
info 부분은 `ApplicationListInfoDto`라고 작성했는데 어떻게 생각하나요?