### PR TITLE
[#85] HttpMessageNotReadableException handling 추가

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/exception/GlobalExceptionHandler.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsm.web.global.exception;
 
 
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 import team.themoment.hellogsm.web.global.exception.model.ExceptionResponseEntity;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +42,7 @@ public class GlobalExceptionHandler {
 
 
     /**
-     * {@code @Valid} 검증에 실패한 경우 던져지는 {@code MethodArgumentNotValidException}를 핸들링합니다.
+     * {@code @Valid} 검증에 실패한 경우 던져지는 {@code MethodArgumentNotValidException}와 {@code HttpMessageNotReadableException}를 핸들링합니다.
      *
      * <p>
      * 반환 메시지 예시:
@@ -56,7 +57,7 @@ public class GlobalExceptionHandler {
      * @param ex {@code MethodArgumentNotValidException}
      * @return ResponseEntity
      */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ExceptionHandler({MethodArgumentNotValidException.class, HttpMessageNotReadableException.class})
     public ResponseEntity<ExceptionResponseEntity> validationException(MethodArgumentNotValidException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
                 .body(new ExceptionResponseEntity(methodArgumentNotValidExceptionToJson(ex)));


### PR DESCRIPTION
## 개요

Boolean값을 validation에서 검증하지 못하는 문제를 발견했습니다

## 본문

GlobalExceptionHandler에 HttpMessageNotReadableException를 핸들링하는 코드를 추가해 해결했습니다