### PR TITLE
Spring Security 인증, 인가 예외처리 구현

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -3,6 +3,8 @@ package team.themoment.hellogsm.web.global.security;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
 import team.themoment.hellogsm.web.global.data.profile.ServerProfile;
 import team.themoment.hellogsm.web.global.security.auth.AuthEnvironment;
+import team.themoment.hellogsm.web.global.security.handler.CustomAccessDeniedHandler;
+import team.themoment.hellogsm.web.global.security.handler.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,9 +37,8 @@ public class SecurityConfig {
     private static final String oauth2LoginEndpointBaseUri = "/auth/v1/oauth2/authorization";
     private static final String oauth2LoginProcessingUri = "/auth/v1/oauth2/code/*";
 
-
-    // TODO
-    //  1. 본인인증 필터 추가
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
     @Configuration
     @EnableWebSecurity
@@ -59,6 +60,9 @@ public class SecurityConfig {
                             .requestMatchers(toH2Console()).permitAll()
             );
             authorizeHttpRequests(http);
+            http.exceptionHandling(handling -> handling
+                    .accessDeniedHandler(accessDeniedHandler)
+                    .authenticationEntryPoint(authenticationEntryPoint));
             return http.build();
         }
     }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/handler/CustomAccessDeniedHandler.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,42 @@
+package team.themoment.hellogsm.web.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException, ServletException {
+        sendErrorResponse(response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response) throws IOException {
+        response.setCharacterEncoding("utf-8");
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        Map<String, Object> map = new HashMap<>();
+        map.put("message", "권한이 없습니다");
+        response.getWriter().write(objectMapper.writeValueAsString(map));
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/handler/CustomAccessDeniedHandler.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/handler/CustomAccessDeniedHandler.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    
     private final ObjectMapper objectMapper;
 
     @Override

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,43 @@
+package team.themoment.hellogsm.web.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+        sendErrorResponse(response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response) throws IOException {
+        response.setCharacterEncoding("utf-8");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        Map<String, Object> map = new HashMap<>();
+        map.put("message", "인증에 실패하였습니다");
+        response.getWriter().write(objectMapper.writeValueAsString(map));
+    }
+}


### PR DESCRIPTION
## 개요

인증, 인가 예외 handler를 추가하였습니다.

## 본문

### 추가

- `CustomAccessDeniedHandler` : 유효하지 않은 인가 요청에서 발생하는 예외를 처리합니다. 403 반환
- `CustomAuthenticationEntryPoint` : 유효하지 않은 인증 요청에서 발생하는 예외를 처리합니다. 401 반환