### PR TITLE
SMS 본인인증 기능 구현 및 일부 Application 수정

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/identity/entity/Identity.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/identity/entity/Identity.java
@@ -34,6 +34,10 @@ public class Identity {
     @Column(name = "birth")
     private LocalDate birth;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender")
+    private Gender gender;
+
     @Column(name = "user_id", unique = true)
     private Long userId;
 }

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/identity/entity/Identity.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/identity/entity/Identity.java
@@ -1,7 +1,10 @@
 package team.themoment.hellogsm.entity.domain.identity.entity;
 
+import java.time.LocalDate;
+
 import jakarta.persistence.*;
 import lombok.*;
+import team.themoment.hellogsm.entity.domain.application.enums.Gender;
 
 /**
  * 본인인증 정보를 저장하는 Identity Entity입니다.
@@ -20,14 +23,17 @@ public class Identity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "identity_id")
-    Long id;
+    private Long id;
 
     @Column(name = "name")
-    String name;
+    private String name;
 
     @Column(name = "phone_number")
-    String phoneNumber;
+    private String phoneNumber;
+
+    @Column(name = "birth")
+    private LocalDate birth;
 
     @Column(name = "user_id", unique = true)
-    Long userId;
+    private Long userId;
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationReqDto.java
@@ -34,14 +34,6 @@ public record ApplicationReqDto(
         String applicantImageUri,
 
         @NotBlank
-        String applicantName,
-
-        @Enumerated(EnumType.STRING)
-        Gender applicantGender,
-
-        LocalDate applicantBirth,
-
-        @NotBlank
         String address,
 
         @NotBlank
@@ -50,9 +42,6 @@ public record ApplicationReqDto(
         @NotBlank
         @Pattern(regexp = "^(CANDIDATE|GRADUATE|GED)$")
         String graduation,
-
-        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
-        String telephone,
 
         @NotBlank
         @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
@@ -87,7 +76,7 @@ public record ApplicationReqDto(
         String thirdDesiredMajor,
 
         @NotBlank
-        String MiddleSchoolGrade,
+        String middleSchoolGrade,
 
         @NotSpace
         String schoolName,
@@ -99,58 +88,6 @@ public record ApplicationReqDto(
         @NotBlank
         String screening
 ) {
-    public Application toEntity(Long id, Long userId) {
-        GraduationStatus graduationStatus = null;
-        Screening screening = null;
-
-        try {
-            graduationStatus = GraduationStatus.valueOf(this.graduation);
-        } catch (IllegalArgumentException e) {
-            throw new ExpectedException("graduation 값이 올바르지 않습니다", HttpStatus.BAD_REQUEST);
-        }
-        try {
-            screening = Screening.valueOf(this.screening);
-        } catch (IllegalArgumentException e) {
-            throw new ExpectedException("screening 값이 올바르지 않습니다", HttpStatus.BAD_REQUEST);
-        }
-
-        DesiredMajor desiredMajor = DesiredMajor.builder()
-                .firstDesiredMajor(Major.valueOf(this.firstDesiredMajor))
-                .secondDesiredMajor(Major.valueOf(this.secondDesiredMajor))
-                .thirdDesiredMajor(Major.valueOf(this.thirdDesiredMajor))
-                .build();
-
-        AdmissionInfo admissionInfo = AdmissionInfo.builder()
-                .id(id)
-                .applicantImageUri(this.applicantImageUri)
-                .applicantName(this.applicantName)
-                .applicantGender(this.applicantGender)
-                .applicantBirth(this.applicantBirth)
-                .address(this.address)
-                .detailAddress(this.detailAddress)
-                .graduation(graduationStatus)
-                .telephone(this.telephone)
-                .applicantPhoneNumber(this.applicantPhoneNumber)
-                .guardianName(this.guardianName)
-                .relationWithApplicant(this.relationWithApplicant)
-                .guardianPhoneNumber(this.guardianPhoneNumber)
-                .teacherName(this.teacherName)
-                .teacherPhoneNumber(this.teacherPhoneNumber)
-                .screening(screening)
-                .desiredMajor(desiredMajor)
-                .build();
-
-        AdmissionStatus admissionStatus = AdmissionStatus.init(id);
-        MiddleSchoolGrade middleSchoolGrade = new MiddleSchoolGrade(id, this.MiddleSchoolGrade);
-
-        return new Application(
-                id,
-                admissionInfo,
-                admissionStatus,
-                middleSchoolGrade,
-                userId
-        );
-    }
 
     @AssertTrue(message = "중복된 전공이 있습니다")
     private boolean isDuplicateMajor() {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationReqDto.java
@@ -45,7 +45,7 @@ public record ApplicationReqDto(
 
         @NotBlank
         @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
-        String applicantPhoneNumber,
+        String telephone,
 
         @NotBlank
         String guardianName,

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -14,7 +14,6 @@ import team.themoment.hellogsm.entity.domain.application.entity.status.Admission
 import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.Major;
 import team.themoment.hellogsm.entity.domain.application.enums.Screening;
-import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
 import team.themoment.hellogsm.web.domain.application.dto.domain.*;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
@@ -24,7 +23,6 @@ import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplica
 import team.themoment.hellogsm.web.domain.application.dto.response.TicketResDto;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
-import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 import java.util.List;
 
@@ -233,5 +231,5 @@ public interface ApplicationMapper {
             @Mapping(source = "admissionInfo.desiredMajor.secondDesiredMajor", target = "desiredMajor.secondDesiredMajor"),
             @Mapping(source = "admissionInfo.desiredMajor.thirdDesiredMajor", target = "desiredMajor.thirdDesiredMajor"),
     })
-    AdmissionInfo toConsistentAdmissionInfoWithIdentityReqDto(AdmissionInfo admissionInfo, IdentityReqDto identityReqDto);
+    AdmissionInfo toConsistentAdmissionInfoWithIdentity(AdmissionInfo admissionInfo, IdentityReqDto identityReqDto);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -14,6 +14,7 @@ import team.themoment.hellogsm.entity.domain.application.entity.status.Admission
 import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.Major;
 import team.themoment.hellogsm.entity.domain.application.enums.Screening;
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
 import team.themoment.hellogsm.web.domain.application.dto.domain.*;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
@@ -22,6 +23,7 @@ import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationsD
 import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplicationRes;
 import team.themoment.hellogsm.web.domain.application.dto.response.TicketResDto;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 import java.util.List;
@@ -179,8 +181,8 @@ public interface ApplicationMapper {
                 .address(applicationReqDto.address())
                 .detailAddress(applicationReqDto.detailAddress())
                 .graduation(GraduationStatus.valueOf(applicationReqDto.graduation()))
-                .telephone(identityDto.phoneNumber())
-                .applicantPhoneNumber(applicationReqDto.applicantPhoneNumber())
+                .telephone(applicationReqDto.telephone())
+                .applicantPhoneNumber(identityDto.phoneNumber())
                 .guardianName(applicationReqDto.guardianName())
                 .relationWithApplicant(applicationReqDto.relationWithApplicant())
                 .guardianPhoneNumber(applicationReqDto.guardianPhoneNumber())
@@ -201,4 +203,35 @@ public interface ApplicationMapper {
                 userId
         );
     }
+
+    @BeanMapping(ignoreUnmappedSourceProperties = {
+            "applicantName",
+            "applicantGender",
+            "applicantBirth",
+            "applicantPhoneNumber",
+            "code"
+    })
+    @Mappings({
+            @Mapping(source = "admissionInfo.id", target = "id"),
+            @Mapping(source = "admissionInfo.applicantImageUri", target = "applicantImageUri"),
+            @Mapping(source = "identityReqDto.name", target = "applicantName"),
+            @Mapping(source = "identityReqDto.gender", target = "applicantGender"),
+            @Mapping(source = "identityReqDto.birth", target = "applicantBirth"),
+            @Mapping(source = "admissionInfo.address", target = "address"),
+            @Mapping(source = "admissionInfo.detailAddress", target = "detailAddress"),
+            @Mapping(source = "admissionInfo.telephone", target = "telephone"),
+            @Mapping(source = "identityReqDto.phoneNumber", target = "applicantPhoneNumber"),
+            @Mapping(source = "admissionInfo.guardianName", target = "guardianName"),
+            @Mapping(source = "admissionInfo.relationWithApplicant", target = "relationWithApplicant"),
+            @Mapping(source = "admissionInfo.guardianPhoneNumber", target = "guardianPhoneNumber"),
+            @Mapping(source = "admissionInfo.screening", target = "screening"),
+            @Mapping(source = "admissionInfo.schoolName", target = "schoolName"),
+            @Mapping(source = "admissionInfo.schoolLocation", target = "schoolLocation"),
+            @Mapping(source = "admissionInfo.teacherName", target = "teacherName"),
+            @Mapping(source = "admissionInfo.teacherPhoneNumber", target = "teacherPhoneNumber"),
+            @Mapping(source = "admissionInfo.desiredMajor.firstDesiredMajor", target = "desiredMajor.firstDesiredMajor"),
+            @Mapping(source = "admissionInfo.desiredMajor.secondDesiredMajor", target = "desiredMajor.secondDesiredMajor"),
+            @Mapping(source = "admissionInfo.desiredMajor.thirdDesiredMajor", target = "desiredMajor.thirdDesiredMajor"),
+    })
+    AdmissionInfo toConsistentAdmissionInfoWithIdentityReqDto(AdmissionInfo admissionInfo, IdentityReqDto identityReqDto);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -2,20 +2,27 @@ package team.themoment.hellogsm.web.domain.application.mapper;
 
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
+
+import io.micrometer.common.lang.Nullable;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
 import team.themoment.hellogsm.entity.domain.application.entity.admission.AdmissionInfo;
+import team.themoment.hellogsm.entity.domain.application.entity.admission.DesiredMajor;
 import team.themoment.hellogsm.entity.domain.application.entity.grade.GedAdmissionGrade;
 import team.themoment.hellogsm.entity.domain.application.entity.grade.GraduateAdmissionGrade;
+import team.themoment.hellogsm.entity.domain.application.entity.grade.MiddleSchoolGrade;
 import team.themoment.hellogsm.entity.domain.application.entity.status.AdmissionStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
+import team.themoment.hellogsm.entity.domain.application.enums.Major;
+import team.themoment.hellogsm.entity.domain.application.enums.Screening;
 import team.themoment.hellogsm.web.domain.application.dto.domain.*;
+import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListInfoDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationsDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplicationRes;
 import team.themoment.hellogsm.web.domain.application.dto.response.TicketResDto;
-
-import java.util.List;
+import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
+import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 import java.util.List;
 
@@ -154,4 +161,44 @@ public interface ApplicationMapper {
     ApplicationsDto applicationToApplicationsDto(Application applicationList);
 
     List<ApplicationsDto> applicationListToApplicationsDtoList(List<Application> applicationList);
+
+    default Application applicationReqDtoAndIdentityDtoToApplication(ApplicationReqDto applicationReqDto, IdentityDto identityDto, Long userId, @Nullable Long appId) {
+
+        DesiredMajor desiredMajor = DesiredMajor.builder()
+                .firstDesiredMajor(Major.valueOf(applicationReqDto.firstDesiredMajor()))
+                .secondDesiredMajor(Major.valueOf(applicationReqDto.secondDesiredMajor()))
+                .thirdDesiredMajor(Major.valueOf(applicationReqDto.thirdDesiredMajor()))
+                .build();
+
+        AdmissionInfo admissionInfo = AdmissionInfo.builder()
+                .id(userId)
+                .applicantImageUri(applicationReqDto.applicantImageUri())
+                .applicantName(identityDto.name())
+                .applicantGender(identityDto.gender())
+                .applicantBirth(identityDto.birth())
+                .address(applicationReqDto.address())
+                .detailAddress(applicationReqDto.detailAddress())
+                .graduation(GraduationStatus.valueOf(applicationReqDto.graduation()))
+                .telephone(identityDto.phoneNumber())
+                .applicantPhoneNumber(applicationReqDto.applicantPhoneNumber())
+                .guardianName(applicationReqDto.guardianName())
+                .relationWithApplicant(applicationReqDto.relationWithApplicant())
+                .guardianPhoneNumber(applicationReqDto.guardianPhoneNumber())
+                .teacherName(applicationReqDto.teacherName())
+                .teacherPhoneNumber(applicationReqDto.teacherPhoneNumber())
+                .screening(Screening.valueOf(applicationReqDto.screening()))
+                .desiredMajor(desiredMajor)
+                .build();
+
+        AdmissionStatus admissionStatus = AdmissionStatus.init(userId);
+        MiddleSchoolGrade middleSchoolGrade = new MiddleSchoolGrade(userId, applicationReqDto.middleSchoolGrade());
+
+        return new Application(
+                userId,
+                admissionInfo,
+                admissionStatus,
+                middleSchoolGrade,
+                userId
+        );
+    }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CreateApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CreateApplicationServiceImpl.java
@@ -3,9 +3,15 @@ package team.themoment.hellogsm.web.domain.application.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.hellogsm.web.domain.application.mapper.ApplicationMapper;
 import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
 import team.themoment.hellogsm.web.domain.application.service.CreateApplicationService;
+import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
+import team.themoment.hellogsm.web.domain.identity.mapper.IdentityMapper;
+import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
 import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
@@ -19,6 +25,7 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 @RequiredArgsConstructor
 public class CreateApplicationServiceImpl implements CreateApplicationService {
     private final UserRepository userRepository;
+    private final IdentityRepository identityRepository;
     private final ApplicationRepository applicationRepository;
 
     @Override
@@ -27,7 +34,12 @@ public class CreateApplicationServiceImpl implements CreateApplicationService {
             throw new ExpectedException("존재하지 않는 유저입니다", HttpStatus.BAD_REQUEST);
         if (applicationRepository.existsByUserId(userId))
             throw new ExpectedException("원서가 이미 존재합니다", HttpStatus.BAD_REQUEST);
+        Identity identity = identityRepository.findByUserId(userId)
+                .orElseThrow(() -> new ExpectedException("Identity가 존재하지 않습니다", HttpStatus.BAD_REQUEST));
 
-        applicationRepository.save(body.toEntity(null, userId));
+        IdentityDto identityDto = IdentityMapper.INSTANCE.identityToIdentityDto(identity);
+
+        applicationRepository.save(
+                ApplicationMapper.INSTANCE.applicationReqDtoAndIdentityDtoToApplication(body, identityDto, userId, null));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationServiceImpl.java
@@ -4,9 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.hellogsm.web.domain.application.mapper.ApplicationMapper;
 import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
 import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationService;
+import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
+import team.themoment.hellogsm.web.domain.identity.mapper.IdentityMapper;
+import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
 import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
@@ -14,6 +19,7 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 @RequiredArgsConstructor
 public class ModifyApplicationServiceImpl implements ModifyApplicationService {
     private final UserRepository userRepository;
+    private final IdentityRepository identityRepository;
     private final ApplicationRepository applicationRepository;
 
     @Override
@@ -22,7 +28,12 @@ public class ModifyApplicationServiceImpl implements ModifyApplicationService {
             throw new ExpectedException("존재하지 않는 유저입니다", HttpStatus.BAD_REQUEST);
         Application application = applicationRepository.findByUserId(userId)
                 .orElseThrow(() -> new ExpectedException("원서가 존재하지 않습니다", HttpStatus.BAD_REQUEST));
+        Identity identity = identityRepository.findByUserId(userId)
+                .orElseThrow(() -> new ExpectedException("Identity가 존재하지 않습니다", HttpStatus.BAD_REQUEST));
 
-        applicationRepository.save(body.toEntity(application.getId(), userId));
+        IdentityDto identityDto = IdentityMapper.INSTANCE.identityToIdentityDto(identity);
+
+        applicationRepository.save(
+                ApplicationMapper.INSTANCE.applicationReqDtoAndIdentityDtoToApplication(body, identityDto, userId, application.getId()));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/CodeController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/CodeController.java
@@ -1,0 +1,51 @@
+package team.themoment.hellogsm.web.domain.identity.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeReqDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsm.web.domain.identity.service.AuthenticateCodeService;
+import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
+import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
+
+@RestController
+@RequestMapping("/identity/v1")
+@RequiredArgsConstructor
+public class CodeController {
+    private final AuthenticatedUserManager manager;
+    private final GenerateCodeService generateCodeService;
+    private final AuthenticateCodeService authenticateCodeService;
+
+    @PostMapping("/identity/me/send-code")
+    public ResponseEntity<Map> sendCode(
+            @RequestBody @Valid GenerateCodeReqDto reqDto
+    ) {
+        generateCodeService.execute(manager.getId(), reqDto);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "전송되었습니다."));
+    }
+
+    @PostMapping("/identity/me/send-code-test")
+    public ResponseEntity<Map> sendCodeTest(
+            @RequestBody @Valid GenerateCodeReqDto reqDto
+    ) {
+        var code = generateCodeService.execute(manager.getId(), reqDto);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "전송되었습니다. : " + code));
+    }
+
+    @PostMapping("/identity/me/auth-code")
+    public ResponseEntity<Map> authCode(
+            @RequestBody @Valid AuthenticateCodeReqDto reqDto
+    ) {
+        authenticateCodeService.execute(manager.getId(), reqDto);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "인증되었습니다."));
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -12,6 +12,7 @@ import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
 import team.themoment.hellogsm.web.domain.identity.service.AuthenticateCodeService;
+import team.themoment.hellogsm.web.domain.identity.service.CodeNotificationService;
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
 import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
 import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
@@ -31,6 +32,8 @@ public class IdentityController {
     private final GenerateCodeService generateCodeService;
     private final AuthenticateCodeService authenticateCodeService;
     private final IdentityQuery identityQuery;
+
+    private final CodeNotificationService codeNotificationService;
 
     @PostMapping("/identity/{userId}")
     public ResponseEntity<IdentityDto> createByUserId(
@@ -95,5 +98,11 @@ public class IdentityController {
     ) {
         authenticateCodeService.execute(manager.getId(), reqDto);
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "인증되었습니다."));
+    }
+
+    @GetMapping("/identity/sms/code-test")
+    public ResponseEntity<Map> test() {
+        codeNotificationService.execute("01048276160", "123456");
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "발신되었습니다."));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -7,13 +7,17 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.service.AuthenticateCodeService;
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
+import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
 import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/identity/v1")
@@ -21,34 +25,25 @@ import java.net.URISyntaxException;
 public class IdentityController {
     private final AuthenticatedUserManager manager;
     private final CreateIdentityService createIdentityService;
+    private final GenerateCodeService generateCodeService;
+    private final AuthenticateCodeService authenticateCodeService;
     private final IdentityQuery identityQuery;
 
-    /*
-        Identity 생성 기능은 나중에 핸드폰 본인인증 도입했을 때, 삭제 될 예정
-    */
     @PostMapping("/identity/{userId}")
     public ResponseEntity<IdentityDto> createByUserId(
-            @RequestBody @Valid CreateIdentityReqDto identityReqDto,
+            @RequestBody @Valid CreateIdentityReqDto reqDto,
             @PathVariable Long userId
     ) {
-        IdentityDto identityResDto = createIdentityService.execute(identityReqDto, userId);
+        IdentityDto identityResDto = createIdentityService.execute(reqDto, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(identityResDto);
     }
 
     @PostMapping("/identity/me")
     public ResponseEntity<Object> create(
-            @RequestBody @Valid CreateIdentityReqDto userDto
+            @RequestBody @Valid CreateIdentityReqDto reqDto
     ) {
-        createIdentityService.execute(userDto, manager.getId());
-        URI redirectUri = null;
-        try {
-            redirectUri = new URI("/auth/v1/logout");
-        } catch (URISyntaxException e) {
-            throw new RuntimeException("redirectUri의 syntax가 잘못되었습니다.", e);
-        }
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.setLocation(redirectUri);
-        return new ResponseEntity<>(httpHeaders, HttpStatus.SEE_OTHER);
+        IdentityDto identityResDto = createIdentityService.execute(reqDto, manager.getId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(identityResDto);
     }
 
     @GetMapping("/identity/me")
@@ -63,5 +58,25 @@ public class IdentityController {
     ) {
         IdentityDto identityResDto = identityQuery.execute(userId);
         return ResponseEntity.status(HttpStatus.OK).body(identityResDto);
+    }
+
+    @GetMapping("/identity/me/send-code")
+    public ResponseEntity<Map> sendCode() {
+        generateCodeService.execute(manager.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("Message","전송되었습니다."));
+    }
+
+    @GetMapping("/identity/me/send-code-test")
+    public ResponseEntity<Map> sendCodeTest() {
+        var code = generateCodeService.execute(manager.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("Message","전송되었습니다. : " + code));
+    }
+
+    @PostMapping("/identity/me/auth-code")
+    public ResponseEntity<Map> authCode(
+            @RequestBody @Valid AuthenticateCodeReqDto reqDto
+    ) {
+        authenticateCodeService.execute(manager.getId(), reqDto);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("Message","인증되었습니다."));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -2,10 +2,12 @@ package team.themoment.hellogsm.web.domain.identity.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
@@ -16,7 +18,6 @@ import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
 
 @RestController
@@ -42,8 +43,11 @@ public class IdentityController {
     public ResponseEntity<Object> create(
             @RequestBody @Valid CreateIdentityReqDto reqDto
     ) {
-        IdentityDto identityResDto = createIdentityService.execute(reqDto, manager.getId());
-        return ResponseEntity.status(HttpStatus.CREATED).body(identityResDto);
+        createIdentityService.execute(reqDto, manager.getId());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create("/auth/v1/logout"));
+        // 인증정보 갱신을 위한 로그아웃 uri로 리다이렉트
+        return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
     }
 
     @GetMapping("/identity/me")
@@ -63,13 +67,13 @@ public class IdentityController {
     @GetMapping("/identity/me/send-code")
     public ResponseEntity<Map> sendCode() {
         generateCodeService.execute(manager.getId());
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("Message","전송되었습니다."));
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "전송되었습니다."));
     }
 
     @GetMapping("/identity/me/send-code-test")
     public ResponseEntity<Map> sendCodeTest() {
         var code = generateCodeService.execute(manager.getId());
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("Message","전송되었습니다. : " + code));
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "전송되었습니다. : " + code));
     }
 
     @PostMapping("/identity/me/auth-code")
@@ -77,6 +81,6 @@ public class IdentityController {
             @RequestBody @Valid AuthenticateCodeReqDto reqDto
     ) {
         authenticateCodeService.execute(manager.getId(), reqDto);
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("Message","인증되었습니다."));
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "인증되었습니다."));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeReqDto;
-import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
 import team.themoment.hellogsm.web.domain.identity.service.AuthenticateCodeService;
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
 import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
@@ -32,7 +32,7 @@ public class IdentityController {
 
     @PostMapping("/identity/{userId}")
     public ResponseEntity<IdentityDto> createByUserId(
-            @RequestBody @Valid CreateIdentityReqDto reqDto,
+            @RequestBody @Valid IdentityReqDto reqDto,
             @PathVariable Long userId
     ) {
         IdentityDto identityResDto = createIdentityService.execute(reqDto, userId);
@@ -41,7 +41,7 @@ public class IdentityController {
 
     @PostMapping("/identity/me")
     public ResponseEntity<Object> create(
-            @RequestBody @Valid CreateIdentityReqDto reqDto
+            @RequestBody @Valid IdentityReqDto reqDto
     ) {
         createIdentityService.execute(reqDto, manager.getId());
         HttpHeaders headers = new HttpHeaders();

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -9,18 +9,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
-import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
-import team.themoment.hellogsm.web.domain.identity.service.AuthenticateCodeService;
-import team.themoment.hellogsm.web.domain.identity.service.CodeNotificationService;
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
-import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
 import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
 import team.themoment.hellogsm.web.domain.identity.service.ModifyIdentityService;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 import java.net.URI;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/identity/v1")
@@ -29,11 +24,7 @@ public class IdentityController {
     private final AuthenticatedUserManager manager;
     private final CreateIdentityService createIdentityService;
     private final ModifyIdentityService modifyIdentityService;
-    private final GenerateCodeService generateCodeService;
-    private final AuthenticateCodeService authenticateCodeService;
     private final IdentityQuery identityQuery;
-
-    private final CodeNotificationService codeNotificationService;
 
     @PostMapping("/identity/{userId}")
     public ResponseEntity<IdentityDto> createByUserId(
@@ -78,31 +69,5 @@ public class IdentityController {
     ) {
         IdentityDto identityResDto = identityQuery.execute(userId);
         return ResponseEntity.status(HttpStatus.OK).body(identityResDto);
-    }
-
-    @GetMapping("/identity/me/send-code")
-    public ResponseEntity<Map> sendCode() {
-        generateCodeService.execute(manager.getId());
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "전송되었습니다."));
-    }
-
-    @GetMapping("/identity/me/send-code-test")
-    public ResponseEntity<Map> sendCodeTest() {
-        var code = generateCodeService.execute(manager.getId());
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "전송되었습니다. : " + code));
-    }
-
-    @PostMapping("/identity/me/auth-code")
-    public ResponseEntity<Map> authCode(
-            @RequestBody @Valid AuthenticateCodeReqDto reqDto
-    ) {
-        authenticateCodeService.execute(manager.getId(), reqDto);
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "인증되었습니다."));
-    }
-
-    @GetMapping("/identity/sms/code-test")
-    public ResponseEntity<Map> test() {
-        codeNotificationService.execute("01048276160", "123456");
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "발신되었습니다."));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -15,6 +15,7 @@ import team.themoment.hellogsm.web.domain.identity.service.AuthenticateCodeServi
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
 import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
 import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
+import team.themoment.hellogsm.web.domain.identity.service.ModifyIdentityService;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 import java.net.URI;
@@ -26,6 +27,7 @@ import java.util.Map;
 public class IdentityController {
     private final AuthenticatedUserManager manager;
     private final CreateIdentityService createIdentityService;
+    private final ModifyIdentityService modifyIdentityService;
     private final GenerateCodeService generateCodeService;
     private final AuthenticateCodeService authenticateCodeService;
     private final IdentityQuery identityQuery;
@@ -54,6 +56,17 @@ public class IdentityController {
     public ResponseEntity<IdentityDto> find() {
         IdentityDto identityResDto = identityQuery.execute(manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(identityResDto);
+    }
+
+    @PutMapping("/identity/me")
+    public ResponseEntity<IdentityDto> modify(
+            @RequestBody @Valid IdentityReqDto reqDto
+    ) {
+        modifyIdentityService.execute(reqDto, manager.getId());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create("/auth/v1/logout"));
+        // 굳이 리다이렉트 할 필요는 없는데, create() 랑 리턴 타입을 맞추기 위해 리다이렉트
+        return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
     }
 
     @GetMapping("/identity/{userId}")

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/domain/AuthenticationCode.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/domain/AuthenticationCode.java
@@ -1,0 +1,25 @@
+package team.themoment.hellogsm.web.domain.identity.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@RedisHash(timeToLive = 3600L) // 60 * 60 = 3600 = 1 hour
+public class AuthenticationCode {
+    @Id
+    private String code;
+    @Indexed
+    private Long userId;
+    private Boolean authenticated;
+    private LocalDateTime createdAt; // @RedisHash 의 경우 @CreateAt이나 @PrePersist가 안돼서 저장하기 직전에 직접 생성해서 넣어줄 것
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/domain/AuthenticationCode.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/domain/AuthenticationCode.java
@@ -21,5 +21,6 @@ public class AuthenticationCode {
     @Indexed
     private Long userId;
     private Boolean authenticated;
+    private String phoneNumber;
     private LocalDateTime createdAt; // @RedisHash 의 경우 @CreateAt이나 @PrePersist가 안돼서 저장하기 직전에 직접 생성해서 넣어줄 것
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/domain/IdentityDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/domain/IdentityDto.java
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDate;
 
+import team.themoment.hellogsm.entity.domain.application.enums.Gender;
+
 public record IdentityDto(
         Long id,
         String name,
         String phoneNumber,
         @JsonFormat(pattern="yyyy-MM-dd")
         LocalDate birth,
+        Gender gender,
         Long userId
 ) {
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/domain/IdentityDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/domain/IdentityDto.java
@@ -1,12 +1,15 @@
 package team.themoment.hellogsm.web.domain.identity.dto.domain;
 
-import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
 
 public record IdentityDto(
         Long id,
         String name,
         String phoneNumber,
+        @JsonFormat(pattern="yyyy-MM-dd")
+        LocalDate birth,
         Long userId
-
 ) {
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/AuthenticateCodeReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/AuthenticateCodeReqDto.java
@@ -1,0 +1,8 @@
+package team.themoment.hellogsm.web.domain.identity.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AuthenticateCodeReqDto(
+        @NotNull String code
+) {
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/CreateIdentityReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/CreateIdentityReqDto.java
@@ -4,12 +4,15 @@ import java.time.LocalDate;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import team.themoment.hellogsm.entity.domain.application.enums.Gender;
 
 public record CreateIdentityReqDto(
         @NotNull String code,
         @NotNull String name,
         @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
         @NotNull String phoneNumber,
+        @Pattern(regexp = "^(MALE|FEMALE)$")
+        @NotNull String gender,
         @NotNull LocalDate birth
 ) {
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/CreateIdentityReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/CreateIdentityReqDto.java
@@ -1,13 +1,15 @@
 package team.themoment.hellogsm.web.domain.identity.dto.request;
 
+import java.time.LocalDate;
+
 import jakarta.validation.constraints.NotNull;
-import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+import jakarta.validation.constraints.Pattern;
 
 public record CreateIdentityReqDto(
-        @NotNull
-        String name,
-
-        @NotNull
-        String phoneNumber
+        @NotNull String code,
+        @NotNull String name,
+        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
+        @NotNull String phoneNumber,
+        @NotNull LocalDate birth
 ) {
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/GenerateCodeReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/GenerateCodeReqDto.java
@@ -1,0 +1,10 @@
+package team.themoment.hellogsm.web.domain.identity.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record GenerateCodeReqDto(
+        @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")
+        @NotNull String phoneNumber
+) {
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/IdentityReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/request/IdentityReqDto.java
@@ -4,9 +4,8 @@ import java.time.LocalDate;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import team.themoment.hellogsm.entity.domain.application.enums.Gender;
 
-public record CreateIdentityReqDto(
+public record IdentityReqDto(
         @NotNull String code,
         @NotNull String name,
         @Pattern(regexp = "^0(?:\\d|\\d{2})(?:\\d{3}|\\d{4})\\d{4}$")

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
@@ -2,6 +2,8 @@ package team.themoment.hellogsm.web.domain.identity.mapper;
 
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
+
+import team.themoment.hellogsm.entity.domain.application.enums.Gender;
 import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
@@ -20,6 +22,7 @@ public interface IdentityMapper {
             @Mapping(source = "name", target = "name"),
             @Mapping(source = "phoneNumber", target = "phoneNumber"),
             @Mapping(source = "birth", target = "birth"),
+            @Mapping(source = "gender", target = "gender"),
             @Mapping(source = "userId", target = "userId")
     })
     IdentityDto identityToIdentityDto(Identity identity);
@@ -31,6 +34,7 @@ public interface IdentityMapper {
                 createIdentityReqDto.name(),
                 createIdentityReqDto.phoneNumber(),
                 createIdentityReqDto.birth(),
+                Gender.valueOf(createIdentityReqDto.gender()),
                 userId
         );
     }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
@@ -19,6 +19,7 @@ public interface IdentityMapper {
             @Mapping(source = "id", target = "id"),
             @Mapping(source = "name", target = "name"),
             @Mapping(source = "phoneNumber", target = "phoneNumber"),
+            @Mapping(source = "birth", target = "birth"),
             @Mapping(source = "userId", target = "userId")
     })
     IdentityDto identityToIdentityDto(Identity identity);
@@ -29,6 +30,7 @@ public interface IdentityMapper {
                 null,
                 createIdentityReqDto.name(),
                 createIdentityReqDto.phoneNumber(),
+                createIdentityReqDto.birth(),
                 userId
         );
     }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
@@ -6,7 +6,7 @@ import org.mapstruct.factory.Mappers;
 import team.themoment.hellogsm.entity.domain.application.enums.Gender;
 import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
-import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
 
 @Mapper(
         componentModel = "spring",
@@ -28,13 +28,13 @@ public interface IdentityMapper {
     IdentityDto identityToIdentityDto(Identity identity);
 
     // MapStruct 써서 구현하기 힘들어서 걍 함
-    default Identity CreateIdentityReqDtoToIdentity(CreateIdentityReqDto createIdentityReqDto, Long userId) {
+    default Identity CreateIdentityReqDtoToIdentity(IdentityReqDto identityReqDto, Long userId) {
         return new Identity(
                 null,
-                createIdentityReqDto.name(),
-                createIdentityReqDto.phoneNumber(),
-                createIdentityReqDto.birth(),
-                Gender.valueOf(createIdentityReqDto.gender()),
+                identityReqDto.name(),
+                identityReqDto.phoneNumber(),
+                identityReqDto.birth(),
+                Gender.valueOf(identityReqDto.gender()),
                 userId
         );
     }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
@@ -28,9 +28,9 @@ public interface IdentityMapper {
     IdentityDto identityToIdentityDto(Identity identity);
 
     // MapStruct 써서 구현하기 힘들어서 걍 함
-    default Identity CreateIdentityReqDtoToIdentity(IdentityReqDto identityReqDto, Long userId) {
+    default Identity identityReqDtoToIdentity(IdentityReqDto identityReqDto, Long userId, Long identityId) {
         return new Identity(
-                null,
+                identityId,
                 identityReqDto.name(),
                 identityReqDto.phoneNumber(),
                 identityReqDto.birth(),

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/CodeRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/CodeRepository.java
@@ -8,4 +8,5 @@ import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
 
 public interface CodeRepository extends CrudRepository<AuthenticationCode, String> {
     List<AuthenticationCode> findByUserId(Long userId);
+    void deleteAllByUserId(Long userId);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/CodeRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/CodeRepository.java
@@ -1,0 +1,11 @@
+package team.themoment.hellogsm.web.domain.identity.repository;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
+
+public interface CodeRepository extends CrudRepository<AuthenticationCode, String> {
+    List<AuthenticationCode> findByUserId(Long userId);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/CodeRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/CodeRepository.java
@@ -8,5 +8,4 @@ import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
 
 public interface CodeRepository extends CrudRepository<AuthenticationCode, String> {
     List<AuthenticationCode> findByUserId(Long userId);
-    void deleteAllByUserId(Long userId);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/AuthenticateCodeService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/AuthenticateCodeService.java
@@ -1,0 +1,7 @@
+package team.themoment.hellogsm.web.domain.identity.service;
+
+import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeReqDto;
+
+public interface AuthenticateCodeService {
+    void execute(Long userId, AuthenticateCodeReqDto reqDto);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CodeNotificationService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CodeNotificationService.java
@@ -1,0 +1,5 @@
+package team.themoment.hellogsm.web.domain.identity.service;
+
+public interface CodeNotificationService {
+    void execute(String phoneNumber, String code);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CreateIdentityService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CreateIdentityService.java
@@ -1,7 +1,7 @@
 package team.themoment.hellogsm.web.domain.identity.service;
 
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
-import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
 
 /**
  * identityReqDto와 userId를 받아 Identity를 생성하는 인터페이스입니다.
@@ -10,5 +10,5 @@ import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReq
  *  * @since 1.0.0
  */
 public interface CreateIdentityService {
-    IdentityDto execute(CreateIdentityReqDto reqDto, Long userId);
+    IdentityDto execute(IdentityReqDto reqDto, Long userId);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CreateIdentityService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CreateIdentityService.java
@@ -10,5 +10,5 @@ import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReq
  *  * @since 1.0.0
  */
 public interface CreateIdentityService {
-    IdentityDto execute(CreateIdentityReqDto identityReqDto, Long userId);
+    IdentityDto execute(CreateIdentityReqDto reqDto, Long userId);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/GenerateCodeService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/GenerateCodeService.java
@@ -1,0 +1,5 @@
+package team.themoment.hellogsm.web.domain.identity.service;
+
+public interface GenerateCodeService {
+    String execute(Long userId);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/GenerateCodeService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/GenerateCodeService.java
@@ -1,5 +1,7 @@
 package team.themoment.hellogsm.web.domain.identity.service;
 
+import team.themoment.hellogsm.web.domain.identity.dto.request.GenerateCodeReqDto;
+
 public interface GenerateCodeService {
-    String execute(Long userId);
+    String execute(Long userId, GenerateCodeReqDto reqDto);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/ModifyIdentityService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/ModifyIdentityService.java
@@ -1,0 +1,14 @@
+package team.themoment.hellogsm.web.domain.identity.service;
+
+import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
+
+/**
+ * identityReqDto와 userId를 받아 Identity를 생성하는 인터페이스입니다.
+ *
+ *  * @author 양시준
+ *  * @since 1.0.0
+ */
+public interface ModifyIdentityService {
+    IdentityDto execute(IdentityReqDto reqDto, Long userId);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/AuthenticateCodeServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/AuthenticateCodeServiceImpl.java
@@ -33,8 +33,10 @@ public class AuthenticateCodeServiceImpl implements AuthenticateCodeService {
         AuthenticationCode recentCode = codes.stream()
                 .max(Comparator.comparing(AuthenticationCode::getCreatedAt))
                 .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 ID : "+userId, HttpStatus.BAD_REQUEST));
+
         if (!recentCode.getCode().equals(reqDto.code()))
             throw new ExpectedException("유효하지 않은 code 입니다. 이전 혹은 잘못된 code입니다.", HttpStatus.BAD_REQUEST);
-        codeRepository.save(new AuthenticationCode(recentCode.getCode(), recentCode.getUserId(), true, recentCode.getCreatedAt()));
+
+        codeRepository.save(new AuthenticationCode(recentCode.getCode(), recentCode.getUserId(), true, recentCode.getPhoneNumber(), recentCode.getCreatedAt()));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/AuthenticateCodeServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/AuthenticateCodeServiceImpl.java
@@ -8,19 +8,10 @@ import java.util.Comparator;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
-import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
-import team.themoment.hellogsm.entity.domain.user.entity.User;
-import team.themoment.hellogsm.entity.domain.user.enums.Role;
 import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
-import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeReqDto;
-import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
-import team.themoment.hellogsm.web.domain.identity.mapper.IdentityMapper;
 import team.themoment.hellogsm.web.domain.identity.repository.CodeRepository;
-import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
 import team.themoment.hellogsm.web.domain.identity.service.AuthenticateCodeService;
-import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
-import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 /**

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/AuthenticateCodeServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/AuthenticateCodeServiceImpl.java
@@ -1,0 +1,49 @@
+package team.themoment.hellogsm.web.domain.identity.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+import team.themoment.hellogsm.entity.domain.user.entity.User;
+import team.themoment.hellogsm.entity.domain.user.enums.Role;
+import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
+import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeReqDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.mapper.IdentityMapper;
+import team.themoment.hellogsm.web.domain.identity.repository.CodeRepository;
+import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
+import team.themoment.hellogsm.web.domain.identity.service.AuthenticateCodeService;
+import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
+import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
+import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
+
+/**
+ * CreateIdentityService의 기본 구현체입니다.
+ *
+ * @author 양시준
+ * @since 1.0.0
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(rollbackFor = {Exception.class})
+public class AuthenticateCodeServiceImpl implements AuthenticateCodeService {
+
+    private final CodeRepository codeRepository;
+
+    @Override
+    public void execute(Long userId, AuthenticateCodeReqDto reqDto) {
+        List<AuthenticationCode> codes = codeRepository.findByUserId(userId);
+        AuthenticationCode recentCode = codes.stream()
+                .max(Comparator.comparing(AuthenticationCode::getCreatedAt))
+                .orElseThrow(() -> new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 ID : "+userId, HttpStatus.BAD_REQUEST));
+        if (!recentCode.getCode().equals(reqDto.code()))
+            throw new ExpectedException("유효하지 않은 code 입니다. 이전 혹은 잘못된 code입니다.", HttpStatus.BAD_REQUEST);
+        codeRepository.save(new AuthenticationCode(recentCode.getCode(), recentCode.getUserId(), true, recentCode.getCreatedAt()));
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
@@ -14,7 +14,7 @@ import team.themoment.hellogsm.entity.domain.user.entity.User;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
 import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
-import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
 import team.themoment.hellogsm.web.domain.identity.mapper.IdentityMapper;
 import team.themoment.hellogsm.web.domain.identity.repository.CodeRepository;
 import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
@@ -48,7 +48,7 @@ public class CreateIdentityServiceImpl implements CreateIdentityService {
      * @throws ExpectedException 존재하지 않는 User나 이미 존재하는 Identity일 경우 발생
      */
     @Override
-    public IdentityDto execute(CreateIdentityReqDto identityReqDto, Long userId) {
+    public IdentityDto execute(IdentityReqDto identityReqDto, Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("존재하지 않는 User 입니다", HttpStatus.BAD_REQUEST));
         if (identityRepository.existsByUserId(userId))

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
@@ -1,15 +1,22 @@
 package team.themoment.hellogsm.web.domain.identity.service.impl;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
 import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
 import team.themoment.hellogsm.entity.domain.user.entity.User;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
+import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.CreateIdentityReqDto;
 import team.themoment.hellogsm.web.domain.identity.mapper.IdentityMapper;
+import team.themoment.hellogsm.web.domain.identity.repository.CodeRepository;
 import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
 import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
@@ -28,6 +35,8 @@ public class CreateIdentityServiceImpl implements CreateIdentityService {
 
     private final IdentityRepository identityRepository;
     private final UserRepository userRepository;
+    private final CodeRepository codeRepository;
+
 
     /**
      * identityReqDto와 userId를 인자로 받아서 Identity를 생성하고,
@@ -41,9 +50,16 @@ public class CreateIdentityServiceImpl implements CreateIdentityService {
     @Override
     public IdentityDto execute(CreateIdentityReqDto identityReqDto, Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() ->new ExpectedException("존재하지 않는 User 입니다", HttpStatus.BAD_REQUEST));
+                .orElseThrow(() -> new ExpectedException("존재하지 않는 User 입니다", HttpStatus.BAD_REQUEST));
         if (identityRepository.existsByUserId(userId))
             throw new ExpectedException("이미 존재하는 Identity 입니다", HttpStatus.BAD_REQUEST);
+        List<AuthenticationCode> codes = codeRepository.findByUserId(userId);
+        AuthenticationCode recentCode = codes.stream()
+                .max(Comparator.comparing(AuthenticationCode::getCreatedAt))
+                .orElseThrow(() ->
+                        new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 ID : "+userId, HttpStatus.BAD_REQUEST));
+        if (!recentCode.getCode().equals(identityReqDto.code()) || !recentCode.getAuthenticated())
+            throw new ExpectedException("유효하지 않은 code 입니다. 이전 혹은 잘못되었거나 인증받지 않은 code입니다.", HttpStatus.BAD_REQUEST);
         User identifiedUser = new User(
                 user.getId(),
                 user.getProvider(),

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
@@ -60,6 +60,7 @@ public class CreateIdentityServiceImpl implements CreateIdentityService {
                         new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 ID : "+userId, HttpStatus.BAD_REQUEST));
         if (!recentCode.getCode().equals(identityReqDto.code()) || !recentCode.getAuthenticated())
             throw new ExpectedException("유효하지 않은 code 입니다. 이전 혹은 잘못되었거나 인증받지 않은 code입니다.", HttpStatus.BAD_REQUEST);
+
         User identifiedUser = new User(
                 user.getId(),
                 user.getProvider(),
@@ -69,6 +70,9 @@ public class CreateIdentityServiceImpl implements CreateIdentityService {
         userRepository.save(identifiedUser);
         Identity newIdentity = IdentityMapper.INSTANCE.CreateIdentityReqDtoToIdentity(identityReqDto, userId);
         Identity savedidentity = identityRepository.save(newIdentity);
+
+        codeRepository.deleteAllByUserId(userId); // 인증이 성공한 경우 재사용 방지를 위해 해당 유저의 모든 code 제거
+
         return IdentityMapper.INSTANCE.identityToIdentityDto(savedidentity);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
@@ -68,10 +68,10 @@ public class CreateIdentityServiceImpl implements CreateIdentityService {
                 Role.ROLE_USER
         );
         userRepository.save(identifiedUser);
-        Identity newIdentity = IdentityMapper.INSTANCE.CreateIdentityReqDtoToIdentity(identityReqDto, userId);
+        Identity newIdentity = IdentityMapper.INSTANCE.identityReqDtoToIdentity(identityReqDto, userId, null);
         Identity savedidentity = identityRepository.save(newIdentity);
 
-        codeRepository.deleteAllByUserId(userId); // 인증이 성공한 경우 재사용 방지를 위해 해당 유저의 모든 code 제거
+        codes.forEach(code -> codeRepository.deleteById(code.getCode())); // 인증이 성공한 경우 재사용 방지를 위해 해당 유저의 모든 code 제거
 
         return IdentityMapper.INSTANCE.identityToIdentityDto(savedidentity);
     }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/GenerateCodeServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/GenerateCodeServiceImpl.java
@@ -8,7 +8,9 @@ import java.util.Random;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
+import team.themoment.hellogsm.web.domain.identity.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsm.web.domain.identity.repository.CodeRepository;
+import team.themoment.hellogsm.web.domain.identity.service.CodeNotificationService;
 import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
@@ -19,28 +21,47 @@ public class GenerateCodeServiceImpl implements GenerateCodeService {
     private final static Random RANDOM = new Random();
 
     public final static int DIGIT_NUMBER = 6;
+    public final static int LIMIT_COUNT_CODE_REQUEST = 5;  // code의 만료 시간은 AuthenticationCode에서 찾을 수 있음
     public final static int MAX = (int) Math.pow(10, DIGIT_NUMBER) - 1;
 
     private final CodeRepository codeRepository;
+    private final CodeNotificationService codeNotificationService;
 
     @Override
-    public String execute(Long userId) {
+    public String execute(Long userId, GenerateCodeReqDto reqDto) {
+        if (isLimitedRequest(userId))
+            throw new ExpectedException(String.format(
+                    "너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요. 특정 시간 내 제한 횟수인 %d회를 초과하였습니다.",
+                    LIMIT_COUNT_CODE_REQUEST), HttpStatus.FORBIDDEN);
+
+        final String code = generateUniqueCode();
+        codeRepository.save(new AuthenticationCode(code, userId, false, reqDto.phoneNumber(), LocalDateTime.now()));
+        sendSMS(reqDto.phoneNumber(), code);
+        return code;
+    }
+
+    private Boolean isLimitedRequest(Long userId) {
+        long count = codeRepository.findByUserId(userId).stream().count();
+        return count >= LIMIT_COUNT_CODE_REQUEST;
+    }
+
+    private void sendSMS(String phoneNumber, String code) {
+        codeNotificationService.execute(phoneNumber, code);
+    }
+
+    private String generateUniqueCode() {
         String code;
         do {
             code = getRandomCode();
         } while (isDuplicate(code));
-        long count = codeRepository.findByUserId(userId).stream().count();
-        if (count >= 5) throw new ExpectedException("너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.FORBIDDEN);
-        codeRepository.save(new AuthenticationCode(code, userId, false, LocalDateTime.now()));
-        // TODO send SMS
         return code;
-    }
-
-    public static String getRandomCode() {
-        return String.format("%0"+DIGIT_NUMBER+"d", RANDOM.nextInt(0, MAX + 1));
     }
 
     private Boolean isDuplicate(String code) {
         return codeRepository.findById(code).isPresent();
+    }
+
+    public static String getRandomCode() {
+        return String.format("%0" + DIGIT_NUMBER + "d", RANDOM.nextInt(0, MAX + 1));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/GenerateCodeServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/GenerateCodeServiceImpl.java
@@ -1,0 +1,46 @@
+package team.themoment.hellogsm.web.domain.identity.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
+import team.themoment.hellogsm.web.domain.identity.repository.CodeRepository;
+import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
+import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
+
+@Component
+@RequiredArgsConstructor
+public class GenerateCodeServiceImpl implements GenerateCodeService {
+
+    private final static Random RANDOM = new Random();
+
+    public final static int DIGIT_NUMBER = 6;
+    public final static int MAX = (int) Math.pow(10, DIGIT_NUMBER) - 1;
+
+    private final CodeRepository codeRepository;
+
+    @Override
+    public String execute(Long userId) {
+        String code;
+        do {
+            code = getRandomCode();
+        } while (isDuplicate(code));
+        long count = codeRepository.findByUserId(userId).stream().count();
+        if (count >= 5) throw new ExpectedException("너무 많은 요청이 발생했습니다. 잠시 후 다시 시도해주세요.", HttpStatus.FORBIDDEN);
+        codeRepository.save(new AuthenticationCode(code, userId, false, LocalDateTime.now()));
+        // TODO send SMS
+        return code;
+    }
+
+    public static String getRandomCode() {
+        return String.format("%0"+DIGIT_NUMBER+"d", RANDOM.nextInt(0, MAX + 1));
+    }
+
+    private Boolean isDuplicate(String code) {
+        return codeRepository.findById(code).isPresent();
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/ModifyIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/ModifyIdentityServiceImpl.java
@@ -1,0 +1,80 @@
+package team.themoment.hellogsm.web.domain.identity.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.hellogsm.entity.domain.application.entity.Application;
+import team.themoment.hellogsm.entity.domain.application.entity.admission.AdmissionInfo;
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+import team.themoment.hellogsm.entity.domain.user.entity.User;
+import team.themoment.hellogsm.entity.domain.user.enums.Role;
+import team.themoment.hellogsm.web.domain.application.mapper.ApplicationMapper;
+import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
+import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
+import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
+import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.mapper.IdentityMapper;
+import team.themoment.hellogsm.web.domain.identity.repository.CodeRepository;
+import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
+import team.themoment.hellogsm.web.domain.identity.service.ModifyIdentityService;
+import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
+import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(rollbackFor = {Exception.class})
+public class ModifyIdentityServiceImpl implements ModifyIdentityService {
+
+    private final IdentityRepository identityRepository;
+    private final UserRepository userRepository;
+    private final CodeRepository codeRepository;
+    private final ApplicationRepository applicationRepository; // TODO 양방향 의존성 제거하기 Application <-> Identity - 이벤트로 의존성 해소
+
+    @Override
+    public IdentityDto execute(IdentityReqDto reqDto, Long userId) {
+        if(!userRepository.existsById(userId))
+                throw new ExpectedException("존재하지 않는 User 입니다", HttpStatus.BAD_REQUEST);
+        Identity savedidentity = identityRepository.findByUserId(userId)
+                .orElseThrow(() -> new ExpectedException("존재하지 않는 Identity 입니다", HttpStatus.BAD_REQUEST));
+        List<AuthenticationCode> codes = codeRepository.findByUserId(userId);
+        AuthenticationCode recentCode = codeRepository.findByUserId(userId).stream()
+                .max(Comparator.comparing(AuthenticationCode::getCreatedAt))
+                .orElseThrow(() ->
+                        new ExpectedException("사용자의 code가 존재하지 않습니다. 사용자의 ID : " + userId, HttpStatus.BAD_REQUEST));
+        if (!recentCode.getCode().equals(reqDto.code()) || !recentCode.getAuthenticated())
+            throw new ExpectedException("유효하지 않은 code 입니다. 이전 혹은 잘못되었거나 인증받지 않은 code입니다.", HttpStatus.BAD_REQUEST);
+
+        // Identity의 인증 정보를 Application의 지원자 정보와 일관되도록 하는 로직
+        // 여기서부터
+        Optional<Application> savedApplicationOpt = applicationRepository.findByUserId(userId);
+        if (savedApplicationOpt.isPresent()) {
+            Application savedApplication = savedApplicationOpt.get();
+            AdmissionInfo newAdmissionInfo =
+                    ApplicationMapper.INSTANCE.toConsistentAdmissionInfoWithIdentityReqDto(savedApplication.getAdmissionInfo(), reqDto);
+
+            Application a = applicationRepository.save(
+                    new Application(
+                            savedApplication.getId(),
+                            newAdmissionInfo,
+                            savedApplication.getAdmissionStatus(),
+                            savedApplication.getMiddleSchoolGrade(),
+                            savedApplication.getUserId()
+                    ));
+            var a1 = a;
+        }
+        // 여기까지, Identity 모듈에서 이벤트 발행해서 Application 모듈에서 처리하도록 수정해야 함
+
+        Identity newIdentity = IdentityMapper.INSTANCE.identityReqDtoToIdentity(reqDto, userId, savedidentity.getId());
+        Identity newSavedIdentity = identityRepository.save(newIdentity);
+
+        codes.forEach(code -> codeRepository.deleteById(code.getCode())); // 인증이 성공한 경우 재사용 방지를 위해 해당 유저의 모든 code 제거
+
+        return IdentityMapper.INSTANCE.identityToIdentityDto(newSavedIdentity);
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -58,6 +58,10 @@ public class SecurityConfig {
             http.authorizeHttpRequests(
                     httpRequests -> httpRequests
                             .requestMatchers(toH2Console()).permitAll()
+                            .requestMatchers(HttpMethod.GET, "/identity/v1/identity/me/send-code-test")
+                            .hasAnyRole(
+                                    Role.ROLE_UNAUTHENTICATED.getRole(),
+                                    Role.ROLE_USER.getRole())
             );
             authorizeHttpRequests(http);
             return http.build();
@@ -126,11 +130,9 @@ public class SecurityConfig {
                 )
                 .requestMatchers(
                         HttpMethod.GET,
-                        "/identity/v1/identity/me/send-code-test",
-                        "/identity/v1/identity/me/send-code"
-                ).hasAnyRole(
-                        Role.ROLE_UNAUTHENTICATED.getRole()
-                        // 추가적으로 비용이 발생 가능한 부분이라 더 제한을 둠
+                        "/identity/v1/identity/me/send-code").hasAnyRole(
+                        Role.ROLE_UNAUTHENTICATED.getRole(),
+                        Role.ROLE_USER.getRole()
                 )
                 .requestMatchers("/identity/v1/**").hasAnyRole(
                         Role.ROLE_USER.getRole(),

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -4,6 +4,7 @@ import team.themoment.hellogsm.entity.domain.user.enums.Role;
 import team.themoment.hellogsm.web.global.data.profile.ServerProfile;
 import team.themoment.hellogsm.web.global.security.auth.AuthEnvironment;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -122,6 +123,14 @@ public class SecurityConfig {
                         Role.ROLE_UNAUTHENTICATED.getRole(),
                         Role.ROLE_USER.getRole(),
                         Role.ROLE_ADMIN.getRole()
+                )
+                .requestMatchers(
+                        HttpMethod.GET,
+                        "/identity/v1/identity/me/send-code-test",
+                        "/identity/v1/identity/me/send-code"
+                ).hasAnyRole(
+                        Role.ROLE_UNAUTHENTICATED.getRole()
+                        // 추가적으로 비용이 발생 가능한 부분이라 더 제한을 둠
                 )
                 .requestMatchers("/identity/v1/**").hasAnyRole(
                         Role.ROLE_USER.getRole(),

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/CodeNotificationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/CodeNotificationServiceImpl.java
@@ -1,0 +1,34 @@
+package team.themoment.hellogsm.web.global.thirdParty.aws.service;
+
+import org.springframework.stereotype.Component;
+
+import io.awspring.cloud.sns.sms.SmsMessageAttributes;
+import io.awspring.cloud.sns.sms.SmsType;
+import io.awspring.cloud.sns.sms.SnsSmsTemplate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.hellogsm.web.domain.identity.service.CodeNotificationService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CodeNotificationServiceImpl implements CodeNotificationService {
+    private final static String MAX_PRICE = "1.00";
+    private final SnsSmsTemplate smsTemplate;
+
+    @Override
+    public void execute(String phoneNumber, String code) {
+        log.warn("send to : " + createPhoneNumber(phoneNumber));
+        smsTemplate
+                .send(createPhoneNumber(phoneNumber), createMessage(code), SmsMessageAttributes.builder()
+                        .smsType(SmsType.TRANSACTIONAL).maxPrice(MAX_PRICE).build());
+    }
+
+    private static String createMessage(String code) {
+        return "[Hello, GSM] 본인인증번호 [" + code + "]를 입력해주세요.";
+    }
+
+    private static String createPhoneNumber(String phoneNumber) {
+        return "+82" + phoneNumber.replaceFirst("0","");
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/CodeNotificationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/CodeNotificationServiceImpl.java
@@ -14,14 +14,16 @@ import team.themoment.hellogsm.web.domain.identity.service.CodeNotificationServi
 @Slf4j
 public class CodeNotificationServiceImpl implements CodeNotificationService {
     private final static String MAX_PRICE = "1.00";
+    private final static String SENDER_ID = "hello-gsm";
+    private final static String KR_CODE = "+82";
     private final SnsSmsTemplate smsTemplate;
 
     @Override
     public void execute(String phoneNumber, String code) {
-        log.warn("send to : " + createPhoneNumber(phoneNumber));
+        //TODO 예외처리 해야 함
         smsTemplate
                 .send(createPhoneNumber(phoneNumber), createMessage(code), SmsMessageAttributes.builder()
-                        .smsType(SmsType.TRANSACTIONAL).maxPrice(MAX_PRICE).build());
+                        .smsType(SmsType.TRANSACTIONAL).maxPrice(MAX_PRICE).senderID(SENDER_ID).build());
     }
 
     private static String createMessage(String code) {
@@ -29,6 +31,6 @@ public class CodeNotificationServiceImpl implements CodeNotificationService {
     }
 
     private static String createPhoneNumber(String phoneNumber) {
-        return "+82" + phoneNumber.replaceFirst("0","");
+        return KR_CODE + phoneNumber;
     }
 }

--- a/hellogsm-web/src/main/resources/application-local.yml
+++ b/hellogsm-web/src/main/resources/application-local.yml
@@ -57,6 +57,8 @@ spring:
       credentials:
         access-key: ${AWS_ACCESS_KEY}
         secret-key: ${AWS_SECRET_KEY}
+      sns:
+        region: ap-northeast-1
 
 logging:
   level:

--- a/hellogsm-web/src/main/resources/application-prod.yml
+++ b/hellogsm-web/src/main/resources/application-prod.yml
@@ -46,6 +46,8 @@ spring:
       credentials:
         access-key: ${AWS_ACCESS_KEY}
         secret-key: ${AWS_SECRET_KEY}
+      sns:
+        region: ap-northeast-1
 
 logging:
   level:


### PR DESCRIPTION
## 개요

- AWS SNS 서비스를 사용해 SMS 본인인증을 구현하였습니다.
- 기능을 구현하는데 있어 관련있는 Application 도메인의 일부 코드가 변경되었습니다.

## 본문
### 추가 

- AWS SNS 서비스를 사용해 SMS 본인인증을 구현하였습니다. 
- 인증 코드를 기록하기 위한 Redis 설정/Repository/Entity 가 추가되었습니다.

### 변경 

- Identity 엔티티의 값이 Application 엔티티의 값과 중복되는 값을 Identity에 의존하도록 변경했습니다.
  - 둘 다 중복해서 값을 가지되, Application에서 수정할 수 없고, Identity에서 수정하면 Application의 값도 같이 수정됩니다.
  - Application 생성/수정 api의 request 필드 중 Identity 엔티티와 값이 중복되는 부분은 requset로 받지 않도록 해당 필드를 제거했습니다.

### 기타

AWS SendBox 보호를 받고 있어, 테스트 가능한 전화번호에 제한이 있습니다. 직접 SMS 기능을 테스트하고 싶으시다면 디코로 맨션하셔서 알려주세요.

인증 code를 response 해주는 테스트 용 api가 있긴 하지만, SMS 요청이 발송됩니다. 사용에 주의해주세요.
잦은 요청으로 비용이 걱정되는 경우 해당 로직에 주석을 추가하여 동작하지 않도록 해주세요.