### PR TITLE
[#16] 이미지 업로드 기능 추가

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsm.web.domain.application.controller;
 
 import jakarta.validation.Valid;
+import org.springframework.web.multipart.MultipartFile;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationStatusReqDto;
@@ -41,6 +42,7 @@ public class ApplicationController {
     private final ModifyApplicationStatusService modifyApplicationStatusService;
     private final DeleteApplicationService deleteApplicationService;
     private final QueryTicketsService queryTicketsService;
+    private final ImageSaveService imageSaveService;
 
     @GetMapping("/application/{userId}")
     public SingleApplicationRes readOne(@PathVariable("userId") Long userId) {
@@ -101,5 +103,11 @@ public class ApplicationController {
         if (page < 0 || size < 0)
             throw new ExpectedException("0 이상만 가능합니다", HttpStatus.BAD_REQUEST);
         return queryTicketsService.execute(page, size);
+    }
+
+    @PostMapping("/image")
+    public Map<String, String> uploadImage(@Valid @RequestPart(name = "file") MultipartFile multipartFile) {
+        String url = imageSaveService.execute(multipartFile);
+        return Map.of("url", url);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ImageSaveService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ImageSaveService.java
@@ -1,0 +1,7 @@
+package team.themoment.hellogsm.web.domain.application.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageSaveService {
+    String execute(MultipartFile multipartFile);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/exception/GlobalExceptionHandler.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package team.themoment.hellogsm.web.global.exception;
 
 
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 import team.themoment.hellogsm.web.global.exception.model.ExceptionResponseEntity;
 import lombok.extern.slf4j.Slf4j;
@@ -89,6 +91,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ExceptionResponseEntity> noHandlerFoundException(NoHandlerFoundException ex) {
         return ResponseEntity.status(ex.getStatusCode())
                 .body(new ExceptionResponseEntity(HttpStatus.NOT_FOUND.getReasonPhrase()));
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ExceptionResponseEntity> maxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST.value())
+                .body(new ExceptionResponseEntity("The file is so big and beautiful"));
     }
 
     private static String methodArgumentNotValidExceptionToJson(MethodArgumentNotValidException ex) {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/application/impl/ImageSaveServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/application/impl/ImageSaveServiceImpl.java
@@ -1,0 +1,26 @@
+package team.themoment.hellogsm.web.global.thirdParty.aws.service.application.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import team.themoment.hellogsm.web.domain.application.service.ImageSaveService;
+import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
+import team.themoment.hellogsm.web.global.thirdParty.aws.service.aws.ImageUploadService;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class ImageSaveServiceImpl implements ImageSaveService {
+    private final ImageUploadService imageUploadService;
+
+    @Override
+    public String execute(MultipartFile multipartFile) {
+        if (multipartFile.isEmpty()) throw new ExpectedException("파일이 존재하지 않습니다", HttpStatus.BAD_REQUEST);
+        if (!Objects.requireNonNull(multipartFile.getContentType()).contains("image"))
+            throw new ExpectedException("파일 형식이 올바르지 않습니다", HttpStatus.BAD_REQUEST);
+
+        return imageUploadService.execute(multipartFile);
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/ImageUploadService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/ImageUploadService.java
@@ -1,0 +1,7 @@
+package team.themoment.hellogsm.web.global.thirdParty.aws.service.aws;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageUploadService {
+    String execute(MultipartFile multipartFile);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/ImageUploadServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/ImageUploadServiceImpl.java
@@ -1,0 +1,38 @@
+package team.themoment.hellogsm.web.global.thirdParty.aws.service.aws.impl;
+
+import io.awspring.cloud.s3.S3Resource;
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import team.themoment.hellogsm.web.global.thirdParty.aws.service.aws.ImageUploadService;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageUploadServiceImpl implements ImageUploadService {
+    private final S3Template s3Template;
+
+    @Value("${spring.cloud.aws.s3.bucket-name}")
+    String bucketName;
+
+    public String execute(MultipartFile multipartFile) {
+        String fileExtension = StringUtils.getFilenameExtension(multipartFile.getOriginalFilename());
+        try {
+            S3Resource resource = s3Template.upload(bucketName, createFileName(fileExtension), multipartFile.getInputStream());
+            return resource.getURL().toString();
+        } catch (IOException e) {
+            // TODO 에러 로그
+            throw new RuntimeException("IOException 발생", e);
+        }
+    }
+
+    private static String createFileName(String fileExtension) {
+        return UUID.randomUUID().toString() + LocalDateTime.now() + "." + fileExtension;
+    }
+}

--- a/hellogsm-web/src/main/resources/application-local.yml
+++ b/hellogsm-web/src/main/resources/application-local.yml
@@ -59,6 +59,9 @@ spring:
         secret-key: ${AWS_SECRET_KEY}
       sns:
         region: ap-northeast-1
+      s3:
+        region: ap-northeast-2
+        bucket-name:  ${AWS_BUCKET_NAME}
 
 logging:
   level:

--- a/hellogsm-web/src/main/resources/application-prod.yml
+++ b/hellogsm-web/src/main/resources/application-prod.yml
@@ -48,6 +48,9 @@ spring:
         secret-key: ${AWS_SECRET_KEY}
       sns:
         region: ap-northeast-1
+      s3:
+        region: ap-northeast-2
+        bucket-name:  ${AWS_BUCKET_NAME}
 
 logging:
   level:


### PR DESCRIPTION
## 개요

이미지 업로드 기능을 추가했습니다

## 본문

- aws s3를 사용해 이미지를 저장해 주는 ImageUploadService를 구현했습니다
- 이미지의 형식이 올바른지, 이미지가 들어 있는지 확인해 주고 이미지를 저장해 주는 ImageSaveService를 구현했습니다
- MultipartFile을 받아 서비스로 넘겨주고 url 을 반환해 주는 uploadImage controller를 구현했습니다

### 추가 - optional

- GlobalExceptionHandler에 MaxUploadSizeExceededException 에러 핸들링을 추가했습니다
- 환경 변수에 s3 설정 추가