### PR TITLE
IdentityController 리다이렉트 시 Http Status Code 변경

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -43,7 +43,7 @@ public class IdentityController {
         HttpHeaders headers = new HttpHeaders();
         headers.setLocation(URI.create("/auth/v1/logout"));
         // 인증정보 갱신을 위한 로그아웃 uri로 리다이렉트
-        return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
+        return new ResponseEntity<>(headers, HttpStatus.SEE_OTHER);
     }
 
     @GetMapping("/identity/me")
@@ -60,7 +60,7 @@ public class IdentityController {
         HttpHeaders headers = new HttpHeaders();
         headers.setLocation(URI.create("/auth/v1/logout"));
         // 굳이 리다이렉트 할 필요는 없는데, create() 랑 리턴 타입을 맞추기 위해 리다이렉트
-        return new ResponseEntity<>(headers, HttpStatus.MOVED_PERMANENTLY);
+        return new ResponseEntity<>(headers, HttpStatus.SEE_OTHER);
     }
 
     @GetMapping("/identity/{userId}")


### PR DESCRIPTION
## 개요

IdentityController의 메서드 중 리다이렉트 하는 경우 Http Status Code 변경

## 본문

MOVED_PERMANENTLY(301) 에서 SEE_OTHER(303)로 변경하였습니다.

MOVED_PERMANENTLY는 요청한 리소스가 새로운(리다이렉트 되는) URL로 완전히 옮겨진 경우에 사용합니다.
유저 정보가 변경 된 이후 로그아웃 or 메인으로 이동시키기 위한 response이기 때문에 MOVED_PERMANENTLY는 적절하지 않은 표현이라 생각했습니다.
SEE_OTHER는 요청한 리소스 자체에 연결되지 않고 다른 페이지에 연결되는 경우에 사용합니다.
그래서 더 적절한 SEE_OTHER(303)를 반환하도록 변경했습니다.
