### PR TITLE
`spring-cloud-aws-test` 의존성 추가

### DIFF
--- a/hellogsm-web/build.gradle
+++ b/hellogsm-web/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'io.awspring.cloud:spring-cloud-aws-test:3.0.1'
 
     /** code generator **/
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'


### PR DESCRIPTION
## 개요

aws기능 test를 위해서 `spring-cloud-aws-test` 의존성을 추가하였습니다.
