### PR TITLE
사용하지 않는 통합테스트 클래스 비활성화

### DIFF
--- a/hellogsm-batch/src/test/java/team/themoment/hellogsm/batch/HellogsmBatchApplicationTests.java
+++ b/hellogsm-batch/src/test/java/team/themoment/hellogsm/batch/HellogsmBatchApplicationTests.java
@@ -3,7 +3,7 @@ package team.themoment.hellogsm.batch;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+//@SpringBootTest
 class HellogsmBatchApplicationTests {
 
     @Test

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/HellogsmWebApplicationTests.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/HellogsmWebApplicationTests.java
@@ -3,7 +3,7 @@ package team.themoment.hellogsm.web;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+//@SpringBootTest
 class HellogsmWebApplicationTests {
 
     @Test


### PR DESCRIPTION
## 개요

Spring initializer에서 생성하면 자동으로 추가되는 @SpringBootTest 가 포함된 테스트 객체로 인하여 
gralde로 Test task가 실패하는 문제를 해결하였습니다.
해당 객체의 `@SpringBootTest`를  주석처리하여 해결하였습니다.