### PR TITLE
환경변수병 변경 REDIS_HOST -> HELLO_REDIS_HOST

### DIFF
--- a/hellogsm-web/src/main/resources/application-local.yml
+++ b/hellogsm-web/src/main/resources/application-local.yml
@@ -48,7 +48,7 @@ spring:
       initialize-schema: always
   data:
     redis:
-      host: ${REDIS_HOST}
+      host: ${HELLO_REDIS_HOST}
       port: 6379
   cloud:
     aws:

--- a/hellogsm-web/src/main/resources/application-prod.yml
+++ b/hellogsm-web/src/main/resources/application-prod.yml
@@ -37,7 +37,7 @@ spring:
       initialize-schema: never
   data:
     redis:
-      host: ${REDIS_HOST}
+      host: ${HELLO_REDIS_HOST}
       port: 6379
   cloud:
     aws:


### PR DESCRIPTION
## 개요

환경변수 이름이 `REDIS_HOST` 이라서 Docker-Compose 실행 시 Redis Connect이 되지 않는 문제가 있었습니다.
이름을 `HELLO_REDIS_HOST`로 변경하여 해결하였습니다.
