### PR TITLE
원서 상태 엔티티에 지원 전형 상태 필드 추가

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.Major;
+import team.themoment.hellogsm.entity.domain.application.enums.Screening;
 
 import java.math.BigDecimal;
 
@@ -42,16 +43,16 @@ public class AdmissionStatus {
     private EvaluationStatus secondEvaluation;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "major_submitted_at", nullable = true)
-    private Major majorSubmittedAt;
+    @Column(name = "screening_submitted_at", nullable = true)
+    private Screening screeningSubmittedAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "major_first_evaluation_at", nullable = true)
-    private Major majorFirstEvaluationAt;
+    @Column(name = "screening_first_evaluation_at", nullable = true)
+    private Screening screeningFirstEvaluationAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "major_second_evaluation_at", nullable = true)
-    private Major majorSecondEvaluationAt;
+    @Column(name = "screening_second_evaluation_at", nullable = true)
+    private Screening screeningSecondEvaluationAt;
 
     @Column(name = "registration_number", nullable = true)
     private Long registrationNumber;  // 접수 번호, 원서 제출 기간 후 배정됨
@@ -75,9 +76,9 @@ public class AdmissionStatus {
                 .isPrintsArrived(false)
                 .firstEvaluation(EvaluationStatus.NOT_YET)
                 .secondEvaluation(EvaluationStatus.NOT_YET)
-                .majorSubmittedAt(null)
-                .majorFirstEvaluationAt(null)
-                .majorSecondEvaluationAt(null)
+                .screeningSubmittedAt(null)
+                .screeningFirstEvaluationAt(null)
+                .screeningSecondEvaluationAt(null)
                 .finalMajor(null)
                 .build();
     }

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
@@ -41,6 +41,18 @@ public class AdmissionStatus {
     @Column(name = "second_evaluation", nullable = false)
     private EvaluationStatus secondEvaluation;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "major_submitted_at", nullable = true)
+    private Major majorSubmittedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "major_first_evaluation_at", nullable = true)
+    private Major majorFirstEvaluationAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "major_second_evaluation_at", nullable = true)
+    private Major majorSecondEvaluationAt;
+
     @Column(name = "registration_number", nullable = true)
     private Long registrationNumber;  // 접수 번호, 원서 제출 기간 후 배정됨
 
@@ -63,6 +75,9 @@ public class AdmissionStatus {
                 .isPrintsArrived(false)
                 .firstEvaluation(EvaluationStatus.NOT_YET)
                 .secondEvaluation(EvaluationStatus.NOT_YET)
+                .majorSubmittedAt(null)
+                .majorFirstEvaluationAt(null)
+                .majorSecondEvaluationAt(null)
                 .finalMajor(null)
                 .build();
     }
@@ -75,6 +90,7 @@ public class AdmissionStatus {
         return isPrintsArrived;
     }
 
+    // null이 아닌 기본 값이 있는 경우 기본값 정해주기
     @PrePersist
     public void prePersist() {
         isFinalSubmitted = isFinalSubmitted == null ? false : isFinalSubmitted;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/domain/AdmissionStatusDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/domain/AdmissionStatusDto.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsm.web.domain.application.dto.domain;
 
 import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.Major;
+import team.themoment.hellogsm.entity.domain.application.enums.Screening;
 
 import java.math.BigDecimal;
 
@@ -10,9 +11,9 @@ public record AdmissionStatusDto(
         Boolean isPrintsArrived,
         EvaluationStatus firstEvaluation,
         EvaluationStatus secondEvaluation,
-        Major majorSubmittedAt,
-        Major majorFirstEvaluationAt,
-        Major majorSecondEvaluationAt,
+        Screening screeningSubmittedAt,
+        Screening screeningFirstEvaluationAt,
+        Screening screeningSecondEvaluationAt,
         Long registrationNumber,
         BigDecimal secondScore,
         Major finalMajor

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/domain/AdmissionStatusDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/domain/AdmissionStatusDto.java
@@ -10,6 +10,9 @@ public record AdmissionStatusDto(
         Boolean isPrintsArrived,
         EvaluationStatus firstEvaluation,
         EvaluationStatus secondEvaluation,
+        Major majorSubmittedAt,
+        Major majorFirstEvaluationAt,
+        Major majorSecondEvaluationAt,
         Long registrationNumber,
         BigDecimal secondScore,
         Major finalMajor

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationStatusReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationStatusReqDto.java
@@ -3,7 +3,6 @@ package team.themoment.hellogsm.web.domain.application.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
-import team.themoment.hellogsm.entity.domain.application.enums.Major;
 
 import java.math.BigDecimal;
 
@@ -22,14 +21,14 @@ public record ApplicationStatusReqDto(
         @NotBlank
         String secondEvaluation,
 
-        @Pattern(regexp = "^(AI|IOT|SW|)$") // null 포함
-        String majorSubmittedAt,
+        @Pattern(regexp = "^(GENERAL|SOCIAL|SPECIAL|)$") // null 포함
+        String screeningSubmittedAt,
 
-        @Pattern(regexp = "^(AI|IOT|SW|)$") // null 포함
-        String majorFirstEvaluationAt,
+        @Pattern(regexp = "^(GENERAL|SOCIAL|SPECIAL|)$") // null 포함
+        String screeningFirstEvaluationAt,
 
-        @Pattern(regexp = "^(AI|IOT|SW|)$") // null 포함
-        String majorSecondEvaluationAt,
+        @Pattern(regexp = "^(GENERAL|SOCIAL|SPECIAL|)$") // null 포함
+        String screeningSecondEvaluationAt,
 
         Long registrationNumber,
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationStatusReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationStatusReqDto.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsm.web.domain.application.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import team.themoment.hellogsm.entity.domain.application.enums.Major;
 
 import java.math.BigDecimal;
 
@@ -21,11 +22,20 @@ public record ApplicationStatusReqDto(
         @NotBlank
         String secondEvaluation,
 
+        @Pattern(regexp = "^(AI|IOT|SW|)$") // null 포함
+        String majorSubmittedAt,
+
+        @Pattern(regexp = "^(AI|IOT|SW|)$") // null 포함
+        String majorFirstEvaluationAt,
+
+        @Pattern(regexp = "^(AI|IOT|SW|)$") // null 포함
+        String majorSecondEvaluationAt,
+
         Long registrationNumber,
 
         BigDecimal secondScore,
 
-        @Pattern(regexp = "^(AI|SW|IOT)$")
+        @Pattern(regexp = "^(AI|IOT|SW|)$") // null 포함
         String finalMajor
 ) {
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationsDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationsDto.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsm.web.domain.application.dto.response;
 
 import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
+import team.themoment.hellogsm.entity.domain.application.enums.Major;
 
 public record ApplicationsDto(
         Long applicationId,
@@ -15,6 +16,9 @@ public record ApplicationsDto(
         Boolean isPrintsArrived,
         EvaluationStatus firstEvaluation,
         EvaluationStatus secondEvaluation,
+        Major majorSubmittedAt,
+        Major majorFirstEvaluationAt,
+        Major majorSecondEvaluationAt,
         Long registrationNumber,
         String secondScore
 ) {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationsDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationsDto.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsm.web.domain.application.dto.response;
 import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.Major;
+import team.themoment.hellogsm.entity.domain.application.enums.Screening;
 
 public record ApplicationsDto(
         Long applicationId,
@@ -16,9 +17,9 @@ public record ApplicationsDto(
         Boolean isPrintsArrived,
         EvaluationStatus firstEvaluation,
         EvaluationStatus secondEvaluation,
-        Major majorSubmittedAt,
-        Major majorFirstEvaluationAt,
-        Major majorSecondEvaluationAt,
+        Screening screeningSubmittedAt,
+        Screening screeningFirstEvaluationAt,
+        Screening screeningSecondEvaluationAt,
         Long registrationNumber,
         String secondScore
 ) {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -116,9 +116,9 @@ public interface ApplicationMapper {
             @Mapping(source = "printsArrived", target = "isPrintsArrived"),
             @Mapping(source = "firstEvaluation", target = "firstEvaluation"),
             @Mapping(source = "secondEvaluation", target = "secondEvaluation"),
-            @Mapping(source = "majorSubmittedAt", target = "majorSubmittedAt"),
-            @Mapping(source = "majorFirstEvaluationAt", target = "majorFirstEvaluationAt"),
-            @Mapping(source = "majorSecondEvaluationAt", target = "majorSecondEvaluationAt"),
+            @Mapping(source = "screeningSubmittedAt", target = "screeningSubmittedAt"),
+            @Mapping(source = "screeningFirstEvaluationAt", target = "screeningFirstEvaluationAt"),
+            @Mapping(source = "screeningSecondEvaluationAt", target = "screeningSecondEvaluationAt"),
             @Mapping(source = "registrationNumber", target = "registrationNumber"),
             @Mapping(source = "secondScore", target = "secondScore"),
             @Mapping(source = "finalMajor", target = "finalMajor"),
@@ -160,9 +160,9 @@ public interface ApplicationMapper {
             @Mapping(source = "admissionStatus.isPrintsArrived", target = "isPrintsArrived"),
             @Mapping(source = "admissionStatus.firstEvaluation", target = "firstEvaluation"),
             @Mapping(source = "admissionStatus.secondEvaluation", target = "secondEvaluation"),
-            @Mapping(source = "admissionStatus.majorSubmittedAt", target = "majorSubmittedAt"),
-            @Mapping(source = "admissionStatus.majorFirstEvaluationAt", target = "majorFirstEvaluationAt"),
-            @Mapping(source = "admissionStatus.majorSecondEvaluationAt", target = "majorSecondEvaluationAt"),
+            @Mapping(source = "admissionStatus.screeningSubmittedAt", target = "screeningSubmittedAt"),
+            @Mapping(source = "admissionStatus.screeningFirstEvaluationAt", target = "screeningFirstEvaluationAt"),
+            @Mapping(source = "admissionStatus.screeningSecondEvaluationAt", target = "screeningSecondEvaluationAt"),
             @Mapping(source = "admissionStatus.registrationNumber", target = "registrationNumber"),
             @Mapping(source = "admissionStatus.secondScore", target = "secondScore"),
     })
@@ -170,19 +170,19 @@ public interface ApplicationMapper {
 
     default AdmissionStatus createNewAdmissionStatus(Long admissionStatusId, ApplicationStatusReqDto applicationStatusReqDto) {
         Major finalMajor = null;
-        Major majorSubmittedAt = null;
-        Major majorFirstEvaluationAt = null;
-        Major majorSecondEvaluationAt = null;
+        Screening screeningSubmittedAt = null;
+        Screening screeningFirstEvaluationAt = null;
+        Screening screeningSecondEvaluationAt = null;
 
         try {
             if(applicationStatusReqDto.finalMajor() != null)
                 finalMajor = Major.valueOf(applicationStatusReqDto.finalMajor());
-            if(applicationStatusReqDto.majorSubmittedAt() != null)
-                majorSubmittedAt = Major.valueOf(applicationStatusReqDto.majorSubmittedAt());
-            if(applicationStatusReqDto.majorFirstEvaluationAt() != null)
-                majorFirstEvaluationAt = Major.valueOf(applicationStatusReqDto.majorFirstEvaluationAt());
-            if(applicationStatusReqDto.majorSecondEvaluationAt() != null)
-                majorSecondEvaluationAt = Major.valueOf(applicationStatusReqDto.majorSecondEvaluationAt());
+            if(applicationStatusReqDto.screeningSubmittedAt() != null)
+                screeningSubmittedAt = Screening.valueOf(applicationStatusReqDto.screeningSubmittedAt());
+            if(applicationStatusReqDto.screeningFirstEvaluationAt() != null)
+                screeningFirstEvaluationAt = Screening.valueOf(applicationStatusReqDto.screeningFirstEvaluationAt());
+            if(applicationStatusReqDto.screeningSecondEvaluationAt() != null)
+                screeningSecondEvaluationAt = Screening.valueOf(applicationStatusReqDto.screeningSecondEvaluationAt());
         } catch (Exception ex) {
             throw new RuntimeException("예상하지 못한 에러 발생",ex);
         }
@@ -194,9 +194,9 @@ public interface ApplicationMapper {
                 .secondEvaluation(EvaluationStatus.valueOf(applicationStatusReqDto.secondEvaluation()))
                 .isFinalSubmitted(applicationStatusReqDto.isFinalSubmitted())
                 .registrationNumber(applicationStatusReqDto.registrationNumber())
-                .majorSubmittedAt(majorSubmittedAt)
-                .majorFirstEvaluationAt(majorFirstEvaluationAt)
-                .majorSecondEvaluationAt(majorSecondEvaluationAt)
+                .screeningSubmittedAt(screeningSubmittedAt)
+                .screeningFirstEvaluationAt(screeningFirstEvaluationAt)
+                .screeningSecondEvaluationAt(screeningSecondEvaluationAt)
                 .finalMajor(finalMajor)
                 .secondScore(applicationStatusReqDto.secondScore())
                 .build();

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -11,11 +11,13 @@ import team.themoment.hellogsm.entity.domain.application.entity.grade.GedAdmissi
 import team.themoment.hellogsm.entity.domain.application.entity.grade.GraduateAdmissionGrade;
 import team.themoment.hellogsm.entity.domain.application.entity.grade.MiddleSchoolGrade;
 import team.themoment.hellogsm.entity.domain.application.entity.status.AdmissionStatus;
+import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.Major;
 import team.themoment.hellogsm.entity.domain.application.enums.Screening;
 import team.themoment.hellogsm.web.domain.application.dto.domain.*;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationStatusReqDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListInfoDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationsDto;
@@ -114,6 +116,9 @@ public interface ApplicationMapper {
             @Mapping(source = "printsArrived", target = "isPrintsArrived"),
             @Mapping(source = "firstEvaluation", target = "firstEvaluation"),
             @Mapping(source = "secondEvaluation", target = "secondEvaluation"),
+            @Mapping(source = "majorSubmittedAt", target = "majorSubmittedAt"),
+            @Mapping(source = "majorFirstEvaluationAt", target = "majorFirstEvaluationAt"),
+            @Mapping(source = "majorSecondEvaluationAt", target = "majorSecondEvaluationAt"),
             @Mapping(source = "registrationNumber", target = "registrationNumber"),
             @Mapping(source = "secondScore", target = "secondScore"),
             @Mapping(source = "finalMajor", target = "finalMajor"),
@@ -155,10 +160,47 @@ public interface ApplicationMapper {
             @Mapping(source = "admissionStatus.isPrintsArrived", target = "isPrintsArrived"),
             @Mapping(source = "admissionStatus.firstEvaluation", target = "firstEvaluation"),
             @Mapping(source = "admissionStatus.secondEvaluation", target = "secondEvaluation"),
+            @Mapping(source = "admissionStatus.majorSubmittedAt", target = "majorSubmittedAt"),
+            @Mapping(source = "admissionStatus.majorFirstEvaluationAt", target = "majorFirstEvaluationAt"),
+            @Mapping(source = "admissionStatus.majorSecondEvaluationAt", target = "majorSecondEvaluationAt"),
             @Mapping(source = "admissionStatus.registrationNumber", target = "registrationNumber"),
             @Mapping(source = "admissionStatus.secondScore", target = "secondScore"),
     })
     ApplicationsDto applicationToApplicationsDto(Application applicationList);
+
+    default AdmissionStatus createNewAdmissionStatus(Long admissionStatusId, ApplicationStatusReqDto applicationStatusReqDto) {
+        Major finalMajor = null;
+        Major majorSubmittedAt = null;
+        Major majorFirstEvaluationAt = null;
+        Major majorSecondEvaluationAt = null;
+
+        try {
+            if(applicationStatusReqDto.finalMajor() != null)
+                finalMajor = Major.valueOf(applicationStatusReqDto.finalMajor());
+            if(applicationStatusReqDto.majorSubmittedAt() != null)
+                majorSubmittedAt = Major.valueOf(applicationStatusReqDto.majorSubmittedAt());
+            if(applicationStatusReqDto.majorFirstEvaluationAt() != null)
+                majorFirstEvaluationAt = Major.valueOf(applicationStatusReqDto.majorFirstEvaluationAt());
+            if(applicationStatusReqDto.majorSecondEvaluationAt() != null)
+                majorSecondEvaluationAt = Major.valueOf(applicationStatusReqDto.majorSecondEvaluationAt());
+        } catch (Exception ex) {
+            throw new RuntimeException("예상하지 못한 에러 발생",ex);
+        }
+
+        return AdmissionStatus.builder()
+                .id(admissionStatusId)
+                .isPrintsArrived(applicationStatusReqDto.isPrintsArrived())
+                .firstEvaluation(EvaluationStatus.valueOf(applicationStatusReqDto.firstEvaluation()))
+                .secondEvaluation(EvaluationStatus.valueOf(applicationStatusReqDto.secondEvaluation()))
+                .isFinalSubmitted(applicationStatusReqDto.isFinalSubmitted())
+                .registrationNumber(applicationStatusReqDto.registrationNumber())
+                .majorSubmittedAt(majorSubmittedAt)
+                .majorFirstEvaluationAt(majorFirstEvaluationAt)
+                .majorSecondEvaluationAt(majorSecondEvaluationAt)
+                .finalMajor(finalMajor)
+                .secondScore(applicationStatusReqDto.secondScore())
+                .build();
+    }
 
     List<ApplicationsDto> applicationListToApplicationsDtoList(List<Application> applicationList);
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationStatusServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationStatusServiceImpl.java
@@ -8,6 +8,7 @@ import team.themoment.hellogsm.entity.domain.application.entity.status.Admission
 import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.Major;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationStatusReqDto;
+import team.themoment.hellogsm.web.domain.application.mapper.ApplicationMapper;
 import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
 import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationStatusService;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
@@ -22,7 +23,8 @@ public class ModifyApplicationStatusServiceImpl implements ModifyApplicationStat
         Application application = applicationRepository.findByUserId(userId)
                 .orElseThrow(() -> new ExpectedException("존재하지 않는 유저입니다", HttpStatus.NOT_FOUND));
 
-        AdmissionStatus admissionStatus = createNewAdmissionStatus(application.getAdmissionStatus().getId(), applicationStatusReqDto);
+        AdmissionStatus admissionStatus = ApplicationMapper.INSTANCE
+                .createNewAdmissionStatus(application.getAdmissionStatus().getId(), applicationStatusReqDto);
 
         Application newApplication = new Application(
                 application.getId(),
@@ -33,24 +35,5 @@ public class ModifyApplicationStatusServiceImpl implements ModifyApplicationStat
         );
 
         applicationRepository.save(newApplication);
-    }
-
-    private AdmissionStatus createNewAdmissionStatus(Long admissionStatusId, ApplicationStatusReqDto applicationStatusReqDto) {
-        Major major = null;
-
-        try {
-            major = Major.valueOf(applicationStatusReqDto.finalMajor());
-        } catch (Exception ignored) {}
-
-        return AdmissionStatus.builder()
-                .id(admissionStatusId)
-                .isPrintsArrived(applicationStatusReqDto.isPrintsArrived())
-                .firstEvaluation(EvaluationStatus.valueOf(applicationStatusReqDto.firstEvaluation()))
-                .secondEvaluation(EvaluationStatus.valueOf(applicationStatusReqDto.secondEvaluation()))
-                .isFinalSubmitted(applicationStatusReqDto.isFinalSubmitted())
-                .registrationNumber(applicationStatusReqDto.registrationNumber())
-                .finalMajor(major)
-                .secondScore(applicationStatusReqDto.secondScore())
-                .build();
     }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -1,6 +1,5 @@
 package team.themoment.hellogsm.web.domain.application.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
@@ -22,17 +22,23 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.multipart.MultipartFile;
 import team.themoment.hellogsm.entity.domain.application.entity.admission.DesiredMajor;
 import team.themoment.hellogsm.entity.domain.application.enums.*;
 import team.themoment.hellogsm.web.domain.application.dto.domain.*;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
+import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListInfoDto;
+import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationsDto;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationStatusReqDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplicationRes;
+import team.themoment.hellogsm.web.domain.application.dto.response.TicketResDto;
 import team.themoment.hellogsm.web.domain.application.service.*;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -45,8 +51,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Tag("restDocsTest")
@@ -145,27 +150,27 @@ class ApplicationControllerTest {
     };
 
     protected final FieldDescriptor[] createRequestFields = new FieldDescriptor[]{
-            fieldWithPath("applicantImageUri").description("지원자 증명사진"),
-            fieldWithPath("address").description("지원자 집주소"),
-            fieldWithPath("detailAddress").description("지원자 상세주소"),
-            fieldWithPath("graduation").description("지원자 중학교 졸업 상태"),
-            fieldWithPath("telephone").description("지원자 집전화 번호"),
-            fieldWithPath("guardianName").description("지원자의 보호자 이름"),
-            fieldWithPath("relationWithApplicant").description("지원자와 보호자의 관계"),
-            fieldWithPath("guardianPhoneNumber").description("보호자 전화번호"),
-            fieldWithPath("teacherName").description("지원자 선생님 이름"),
-            fieldWithPath("teacherPhoneNumber").description("지원자 선생님 전화번호"),
-            fieldWithPath("firstDesiredMajor").description("1지망 학과"),
-            fieldWithPath("secondDesiredMajor").description("2지망 학과"),
-            fieldWithPath("thirdDesiredMajor").description("3지망 학과"),
-            fieldWithPath("middleSchoolGrade").description("중학교 성적 json 형태로"),
-            fieldWithPath("schoolName").description("지원자 학교 이름"),
-            fieldWithPath("schoolLocation").description("지원자 학교 위치"),
-            fieldWithPath("screening").description("지원 전형")
+            fieldWithPath("applicantImageUri").type(STRING).description("지원자 증명사진"),
+            fieldWithPath("address").type(STRING).description("지원자 집주소"),
+            fieldWithPath("detailAddress").type(STRING).description("지원자 상세주소"),
+            fieldWithPath("graduation").type(STRING).description("지원자 중학교 졸업 상태"),
+            fieldWithPath("telephone").type(STRING).description("지원자 집전화 번호"),
+            fieldWithPath("guardianName").type(STRING).description("지원자의 보호자 이름"),
+            fieldWithPath("relationWithApplicant").type(STRING).description("지원자와 보호자의 관계"),
+            fieldWithPath("guardianPhoneNumber").type(STRING).description("보호자 전화번호"),
+            fieldWithPath("teacherName").type(STRING).description("지원자 선생님 이름"),
+            fieldWithPath("teacherPhoneNumber").type(STRING).description("지원자 선생님 전화번호"),
+            fieldWithPath("firstDesiredMajor").type(STRING).description("1지망 학과"),
+            fieldWithPath("secondDesiredMajor").type(STRING).description("2지망 학과"),
+            fieldWithPath("thirdDesiredMajor").type(STRING).description("3지망 학과"),
+            fieldWithPath("middleSchoolGrade").type(STRING).description("중학교 성적 json 형태로"),
+            fieldWithPath("schoolName").type(STRING).description("지원자 학교 이름"),
+            fieldWithPath("schoolLocation").type(STRING).description("지원자 학교 위치"),
+            fieldWithPath("screening").type(STRING).description("지원 전형")
     };
 
 
-            ApplicationReqDto applicationReqDto = new ApplicationReqDto(
+    ApplicationReqDto applicationReqDto = new ApplicationReqDto(
             "https://naver.com",
             "광주소프트웨어마이스터중학교",
             "이세상 어딘가",
@@ -347,16 +352,16 @@ class ApplicationControllerTest {
                 .andExpect(jsonPath("$.admissionGrade.volunteerScore").value(admissionGrade.volunteerScore()))
                 .andExpect(jsonPath("$.admissionGrade.extracurricularSubtotalScore").value(admissionGrade.extracurricularSubtotalScore()))
                 .andDo(this.documentationHandler.document(
-                        pathParameters(parameterWithName("userId").description("조회하고자 하는 USER의 식별자")),
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
-                        responseFields(
-                                Stream.concat(
-                                        Arrays.stream(applicationCommonResponseFields),
-                                        Arrays.stream(generalResponseFields)
-                                ).toArray(FieldDescriptor[]::new)
+                                pathParameters(parameterWithName("userId").description("조회하고자 하는 USER의 식별자")),
+                                requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                                responseFields(
+                                        Stream.concat(
+                                                Arrays.stream(applicationCommonResponseFields),
+                                                Arrays.stream(generalResponseFields)
+                                        ).toArray(FieldDescriptor[]::new)
+                                )
                         )
-                )
-        );
+                );
     }
 
     @Test
@@ -470,6 +475,82 @@ class ApplicationControllerTest {
     }
 
     @Test
+    @DisplayName("원서 전체 조회")
+    void findAll() throws Exception {
+        ApplicationListDto applicationListDto = new ApplicationListDto(
+                new ApplicationListInfoDto(1),
+                List.of(new ApplicationsDto(
+                        1L,
+                        "human",
+                        GraduationStatus.GRADUATE,
+                        "01012341234",
+                        "01012341234",
+                        "휴먼선생",
+                        "01012341234",
+                        true,
+                        true,
+                        EvaluationStatus.NOT_YET,
+                        EvaluationStatus.NOT_YET,
+                        Screening.SPECIAL,
+                        Screening.SOCIAL,
+                        Screening.GENERAL,
+                        1L,
+                        "100"
+                ))
+        );
+
+        Mockito.when(applicationListQuery.execute(any(Integer.class), any(Integer.class))).thenReturn(applicationListDto);
+
+        this.mockMvc.perform(get("/application/v1/application/all")
+                        .param("page", "0")
+                        .param("size", "1")
+                        .cookie(new Cookie("SESSION", "SESSIONID12345"))
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.info.count").value(applicationListDto.info().count()))
+                .andExpect(jsonPath("$.applications[0].applicationId").value(applicationListDto.applications().get(0).applicationId()))
+                .andExpect(jsonPath("$.applications[0].applicantName").value(applicationListDto.applications().get(0).applicantName()))
+                .andExpect(jsonPath("$.applications[0].graduation").value(applicationListDto.applications().get(0).graduation().toString()))
+                .andExpect(jsonPath("$.applications[0].applicantPhoneNumber").value(applicationListDto.applications().get(0).applicantPhoneNumber()))
+                .andExpect(jsonPath("$.applications[0].guardianPhoneNumber").value(applicationListDto.applications().get(0).guardianPhoneNumber()))
+                .andExpect(jsonPath("$.applications[0].teacherName").value(applicationListDto.applications().get(0).teacherName()))
+                .andExpect(jsonPath("$.applications[0].teacherPhoneNumber").value(applicationListDto.applications().get(0).teacherPhoneNumber()))
+                .andExpect(jsonPath("$.applications[0].isFinalSubmitted").value(applicationListDto.applications().get(0).isFinalSubmitted()))
+                .andExpect(jsonPath("$.applications[0].isPrintsArrived").value(applicationListDto.applications().get(0).isPrintsArrived()))
+                .andExpect(jsonPath("$.applications[0].firstEvaluation").value(applicationListDto.applications().get(0).firstEvaluation().toString()))
+                .andExpect(jsonPath("$.applications[0].secondEvaluation").value(applicationListDto.applications().get(0).secondEvaluation().toString()))
+                .andExpect(jsonPath("$.applications[0].registrationNumber").value(applicationListDto.applications().get(0).registrationNumber()))
+                .andExpect(jsonPath("$.applications[0].secondScore").value(applicationListDto.applications().get(0).secondScore()))
+                .andDo(this.documentationHandler.document(
+                        queryParameters(
+                                parameterWithName("page").description("페이지"),
+                                parameterWithName("size").description("원서 크기")
+                        ),
+                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                        responseFields(
+                                fieldWithPath("info.count").type(NUMBER).description("원서 개수"),
+                                fieldWithPath("applications[].applicationId").type(NUMBER).description("원서 식별자"),
+                                fieldWithPath("applications[].applicantName").type(STRING).description("지원자 이름"),
+                                fieldWithPath("applications[].graduation").type(STRING).description("중학교 졸업 상태"),
+                                fieldWithPath("applications[].applicantPhoneNumber").type(STRING).description("지원자 전화번호"),
+                                fieldWithPath("applications[].guardianPhoneNumber").type(STRING).description("보호자 전화번호"),
+                                fieldWithPath("applications[].teacherName").type(STRING).description("선생님 이름"),
+                                fieldWithPath("applications[].teacherPhoneNumber").type(STRING).description("선생님 전화번호"),
+                                fieldWithPath("applications[].isFinalSubmitted").type(BOOLEAN).description("최종 제출 여부"),
+                                fieldWithPath("applications[].isPrintsArrived").type(BOOLEAN).description("서류 도착 여부"),
+                                fieldWithPath("applications[].firstEvaluation").type(STRING).description("1차 평가 결과"),
+                                fieldWithPath("applications[].secondEvaluation").type(STRING).description("2차 평가 결과"),
+                                fieldWithPath("applications[].screeningSubmittedAt").type(STRING).description("최종제출 시 전형 상태"),
+                                fieldWithPath("applications[].screeningFirstEvaluationAt").type(STRING).description("1차 평가 이후 전형 상태"),
+                                fieldWithPath("applications[]screeningSecondEvaluationAt").type(STRING).description("2차 평가 이후 전형 상태"),
+                                fieldWithPath("applications[].registrationNumber").type(NUMBER).description("접수 번호"),
+                                fieldWithPath("applications[].secondScore").type(STRING).description("2차 시험 점수")
+                        )
+                ));
+    }
+
+    @Test
     @DisplayName("원서 상태 수정")
     void modifyStatus() throws Exception {
         ApplicationStatusReqDto applicationStatusReqDto = new ApplicationStatusReqDto(
@@ -509,6 +590,96 @@ class ApplicationControllerTest {
                                 fieldWithPath("registrationNumber").type(NUMBER).description("접수 번호"),
                                 fieldWithPath("secondScore").type(NUMBER).description("2차 평가 점수"),
                                 fieldWithPath("finalMajor").type(STRING).description("최종 합격 전공")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("원서 삭제")
+    void deleteApplication() throws Exception {
+        doNothing().when(deleteApplicationService).execute(any(Long.class));
+
+        this.mockMvc.perform(delete("/application/v1/application/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new Cookie("SESSION", "SESSIONID12345")))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andDo(this.documentationHandler.document(
+                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다."))
+                ));
+    }
+
+    @Test
+    @DisplayName("수험표 출력")
+    void tickets() throws Exception {
+        List<TicketResDto> ticketResDto = List.of(
+                new TicketResDto(
+                        1L,
+                        "누군가",
+                        Gender.MALE,
+                        "20030423",
+                        "https://naver.com",
+                        "이세상 어딘가",
+                        GraduationStatus.GRADUATE,
+                        1L
+                )
+        );
+
+        Mockito.when(queryTicketsService.execute(any(Integer.class), any(Integer.class))).thenReturn(ticketResDto);
+
+        this.mockMvc.perform(get("/application/v1/tickets")
+                        .param("page", "0")
+                        .param("size", "1")
+                        .cookie(new Cookie("SESSION", "SESSIONID12345"))
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].applicationId").value(ticketResDto.get(0).applicationId()))
+                .andExpect(jsonPath("$[0].applicantName").value(ticketResDto.get(0).applicantName()))
+                .andExpect(jsonPath("$[0].applicantGender").value(ticketResDto.get(0).applicantGender().toString()))
+                .andExpect(jsonPath("$[0].applicantBirth").value(ticketResDto.get(0).applicantBirth()))
+                .andExpect(jsonPath("$[0].applicantImageUri").value(ticketResDto.get(0).applicantImageUri()))
+                .andExpect(jsonPath("$[0].address").value(ticketResDto.get(0).address()))
+                .andExpect(jsonPath("$[0].graduation").value(ticketResDto.get(0).graduation().toString()))
+                .andExpect(jsonPath("$[0].registrationNumber").value(ticketResDto.get(0).registrationNumber()))
+                .andDo(this.documentationHandler.document(
+                        queryParameters(
+                                parameterWithName("page").description("페이지"),
+                                parameterWithName("size").description("원서 크기")
+                        ),
+                        responseFields(
+                                fieldWithPath("[].applicationId").type(NUMBER).description("원서 식별자"),
+                                fieldWithPath("[].applicantName").type(STRING).description("지원자 이름"),
+                                fieldWithPath("[].applicantGender").type(STRING).description("지원자 성별"),
+                                fieldWithPath("[].applicantBirth").type(STRING).description("지원자 생년월일"),
+                                fieldWithPath("[].applicantImageUri").type(STRING).description("지원자 증명사진"),
+                                fieldWithPath("[].address").type(STRING).description("지원자 주소"),
+                                fieldWithPath("[].graduation").type(STRING).description("지원자 졸업 상태"),
+                                fieldWithPath("[].registrationNumber").type(NUMBER).description("접수 번호")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("증명사진 업로드")
+    void uploadImage() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "image.png", "image/png",
+                "<<image data>>".getBytes());
+
+        Mockito.when(imageSaveService.execute(any(MultipartFile.class))).thenReturn("https://hellogsm.kr");
+
+        this.mockMvc.perform(multipart("/application/v1/image")
+                        .file(file)
+                        .cookie(new Cookie("SESSION", "SESSIONID12345"))
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+
+                )
+                .andDo(this.documentationHandler.document(
+                        requestParts(
+                                partWithName("file").description("이미지 파일")
+                        ),
+                        responseFields(
+                                fieldWithPath("url").type(STRING).description("이미지 url")
                         )
                 ));
     }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -136,6 +136,9 @@ class ApplicationControllerTest {
             fieldWithPath("admissionStatus.isPrintsArrived").type(BOOLEAN).description("서류 도착 여부"),
             fieldWithPath("admissionStatus.firstEvaluation").type(STRING).description("첫 번째 시험 평가 결과"),
             fieldWithPath("admissionStatus.secondEvaluation").type(STRING).description("두 번째 시험 평가 결과"),
+            fieldWithPath("admissionStatus.screeningSubmittedAt").type(STRING).description("최종제출 시 전형 상태").optional(),
+            fieldWithPath("admissionStatus.screeningFirstEvaluationAt").type(STRING).description("1차 평가 이후 전형 상태").optional(),
+            fieldWithPath("admissionStatus.screeningSecondEvaluationAt").type(STRING).description("2차 평가 이후 전형 상태").optional(),
             fieldWithPath("admissionStatus.registrationNumber").type(NUMBER).description("접수 번호").optional(),
             fieldWithPath("admissionStatus.secondScore").type(NUMBER).description("2차 점수").optional(),
             fieldWithPath("admissionStatus.finalMajor").type(STRING).description("최종 학과").optional()
@@ -234,6 +237,9 @@ class ApplicationControllerTest {
                         EvaluationStatus.NOT_YET,
                         null,
                         null,
+                        null,
+                        null,
+                        null,
                         null
                 ));
     }
@@ -264,6 +270,9 @@ class ApplicationControllerTest {
                 .andExpect(jsonPath("$.admissionStatus.isPrintsArrived").value(singleApplicationRes.admissionStatus().isPrintsArrived()))
                 .andExpect(jsonPath("$.admissionStatus.firstEvaluation").value(singleApplicationRes.admissionStatus().firstEvaluation().toString()))
                 .andExpect(jsonPath("$.admissionStatus.secondEvaluation").value(singleApplicationRes.admissionStatus().secondEvaluation().toString()))
+                .andExpect(jsonPath("$.admissionStatus.screeningSubmittedAt").value(singleApplicationRes.admissionStatus().screeningSubmittedAt()))
+                .andExpect(jsonPath("$.admissionStatus.screeningFirstEvaluationAt").value(singleApplicationRes.admissionStatus().screeningFirstEvaluationAt()))
+                .andExpect(jsonPath("$.admissionStatus.screeningSecondEvaluationAt").value(singleApplicationRes.admissionStatus().screeningSecondEvaluationAt()))
                 .andExpect(jsonPath("$.admissionStatus.registrationNumber").value(singleApplicationRes.admissionStatus().registrationNumber()))
                 .andExpect(jsonPath("$.admissionStatus.secondScore").value(singleApplicationRes.admissionStatus().secondScore()))
                 .andExpect(jsonPath("$.admissionStatus.finalMajor").value(singleApplicationRes.admissionStatus().finalMajor()))
@@ -468,6 +477,9 @@ class ApplicationControllerTest {
                 true,
                 "NOT_YET",
                 "NOT_YET",
+                "SPECIAL",
+                "SOCIAL",
+                "GENERAL",
                 1L,
                 BigDecimal.valueOf(100),
                 "SW"
@@ -491,6 +503,9 @@ class ApplicationControllerTest {
                                 fieldWithPath("isPrintsArrived").type(BOOLEAN).description("서류 도착 여부"),
                                 fieldWithPath("firstEvaluation").type(STRING).description("1차 평과 결과"),
                                 fieldWithPath("secondEvaluation").type(STRING).description("2차 평과 결과"),
+                                fieldWithPath("screeningSubmittedAt").type(STRING).description("최종제출 시 전형 상태"),
+                                fieldWithPath("screeningFirstEvaluationAt").type(STRING).description("1차 평가 이후 전형 상태"),
+                                fieldWithPath("screeningSecondEvaluationAt").type(STRING).description("2차 평가 이후 전형 상태"),
                                 fieldWithPath("registrationNumber").type(NUMBER).description("접수 번호"),
                                 fieldWithPath("secondScore").type(NUMBER).description("2차 평가 점수"),
                                 fieldWithPath("finalMajor").type(STRING).description("최종 합격 전공")


### PR DESCRIPTION
## 개요

1,2차 평가에서 지원 전형이 변경되는 경우가 있어, 1,2차 시험 전후로 지원 전형 상태를 기록할 수 있도록 전형 상태 필드를 추가하였습니다.

## 본문

### 추가 

`AdmissionStatus` 에 필드 추가
- `screeningSubmittedAt` :  최종제출 시 전형 상태
- `screeningFirstEvaluationAt` :  1차 평가 이후 전형 상태
- `screeningSecondEvaluationAt` : 2차 평가 이후 전형상태

또한 관련된 DTO에도 동일한 역할의 변수 추가
