### PR TITLE
controller 테스트코드 리팩토링 및 restdocs 작성

### DIFF
--- a/hellogsm-web/src/docs/asciidoc/index.adoc
+++ b/hellogsm-web/src/docs/asciidoc/index.adoc
@@ -35,8 +35,9 @@ AsciiDoc 문법에 관한 내용은 link:https://docs.asciidoctor.org/asciidoc/l
 [cols="2,5,3"]
 |====
 |환경         |DNS |비고
-|개발(dev)    | link:[https://dev-api.hellogsm.kr] |API 문서 제공
-|운영(prod)   | link:[https://api.hellogsm.kr] | API 문서 미제공
+|작성중    | 입니다 |
+// |개발(dev)    | link:[https://dev-api.hellogsm.kr] |API 문서 제공
+// |운영(prod)   | link:[https://api.hellogsm.kr] | API 문서 미제공
 |====
 
 NOTE: 해당 프로젝트 API문서는 개발환경까지 노출되는 것을 권장합니다.
@@ -46,104 +47,337 @@ CAUTION: 운영환경에 노출될 경우 보안 관련 문제가 발생할 수 
 === 응답형식
 프로젝트는 다음과 같은 응답형식을 제공합니다.
 
-==== 정상(200, OK)
+// ==== 정상(200, OK)
+//
+// |====
+// |응답데이터가 없는 경우|응답데이터가 있는 경우
+//
+// a|[source,json]
+// // ----
+// // {
+// //     "code": "0000", // 정상인 경우 '0000'
+// //     "message": "OK", // 정상인 경우 'OK'
+// //     "data": null
+// // }
+// // ----
+//
+// a|[source,json]
+// // ----
+// // {
+// //     "code": "0000", // 정상인 경우 '0000'
+// //     "message": "OK", // 정상인 경우 'OK'
+// //     "data": {
+// //         "name": "honeymon-enterprise"
+// //     }
+// // }
+// // ----
+// |====
 
-|====
-|응답데이터가 없는 경우|응답데이터가 있는 경우
-
-a|[source,json]
-----
-{
-    "code": "0000", // 정상인 경우 '0000'
-    "message": "OK", // 정상인 경우 'OK'
-    "data": null
-}
-----
-
-a|[source,json]
-----
-{
-    "code": "0000", // 정상인 경우 '0000'
-    "message": "OK", // 정상인 경우 'OK'
-    "data": {
-        "name": "honeymon-enterprise"
-    }
-}
-----
-|====
+// ==== 상태코드(HttpStatus)
+// 응답시 다음과 같은 응답상태 헤더, 응답코드 및 응답메시지를 제공합니다.
+//
+// [cols="3,1,3,3"]
+// |====
+// |HttpStatus |코드 |메시지 |설명
+//
+// |`OK(200)` |`0000` |"OK" |정상 응답
+// |`INTERNAL_SERVER_ERROR(500)`|`S5XX` |"알 수 없는 에러가 발생했습니다. 관리자에게 문의하세요." |서버 내부 오류
+// |`FORBIDDEN(403)`|`C403` |"[AccessDenied] 잘못된 접근입니다." |비인가 접속입니다.
+// |`BAD_REQUEST(400)`|`C400` |"잘못된 요청입니다. 요청내용을 확인하세요." |요청값 누락 혹은 잘못된 기입
+// |`NOT_FOUND(404)`|`C404` |"상황에 따라 다름" |요청값 누락 혹은 잘못된 기입
+//
+// |====
 
 ==== 상태코드(HttpStatus)
-응답시 다음과 같은 응답상태 헤더, 응답코드 및 응답메시지를 제공합니다.
+응답시 다음과 같은 응답상태 헤더를 제공합니다.
 
-[cols="3,1,3,3"]
+[cols="2,3"]
 |====
-|HttpStatus |코드 |메시지 |설명
+|HttpStatus |설명
+|`OK(200)`|정상 응답
+|`CREATED(201)`|데이터가 새로(수정X) 추가된 경우
+|`SEE_OTHER(303)`|요청이 성공하였으며, 권한이 변경되어 로그아웃이 필요한 경우
+|`BAD_REQUEST(400)`|요청값 누락, 잘못된 기입, 존재하지 않는 자료 요청
+|`FORBIDDEN(401)`|사용자를 식별이 불가능
+|`FORBIDDEN(403)`|사용자를 식별하였으나, 해당 사용자가 접근할 수 없는 요청(권한 없음)
+|`NOT_FOUND(404)`|존재하지 않는 엔드포인트
+|====
 
-|`OK(200)` |`0000` |"OK" |정상 응답
-|`INTERNAL_SERVER_ERROR(500)`|`S5XX` |"알 수 없는 에러가 발생했습니다. 관리자에게 문의하세요." |서버 내부 오류
-|`FORBIDDEN(403)`|`C403` |"[AccessDenied] 잘못된 접근입니다." |비인가 접속입니다.
-|`BAD_REQUEST(400)`|`C400` |"잘못된 요청입니다. 요청내용을 확인하세요." |요청값 누락 혹은 잘못된 기입
-|`NOT_FOUND(404)`|`C404` |"상황에 따라 다름" |요청값 누락 혹은 잘못된 기입
+==== 사용자 권한(Role)
+한 사용자는 하나의 권한만 가질 수 있습니다.
 
+[cols="2,3"]
+|====
+|Name |설명
+|`ROLE_UNAUTHENTICATED`|본인인증이 되지 않은 사용자
+|`ROLE_USER`|본인인증을 완료한 사용자
+|`ROLE_ADMIN`|관리자
 |====
 
 = API 명세
 
-== 회원(User)
-회원의 인증 정보(id, 권한 등)를 조회할 수 있습니다.
+== user/v1/
+*회원(User)*
 
-=== ID로 USER 조회
-ID로 USER를 조회합니다.
+회원의 권환과 OAuth2 정보를 관리합니다.
+
+=== Enum 정리
+
+==== EvaluationStatus
+시험 결과 상태
+[cols="2,3"]
+|====
+|Name |설명
+|`ROLE_UNAUTHENTICATED`|본인인증이 되지 않은 사용자
+|`ROLE_USER`|본인인증을 완료한 사용자
+|`ROLE_ADMIN`|관리자
+|====
+
+=== [GET] user/{userId}
+USER ID를 사용하여 특정 사용자 정보를 가져오는 엔드포인트입니다.
 
 WARNING: `userId` 를 입력해야만 합니다.
 
 ==== Request
-operation::user/find-by-user-id[snippets='curl-request,httpie-request,http-request,path-parameters']
+operation::user/find-by-user-id[snippets='curl-request,http-request,path-parameters']
 
 ==== Response
 operation::user/find-by-user-id[snippets='http-response,response-fields']
 
-=== 인증된 USER 조회
-현재 인증되어있는 회원을 조회합니다.
+=== [GET] user/me
+현재 사용자 정보를 가져오는 엔드포인트입니다.
 
 ==== Request
-operation::user/find-by-authenticated[snippets='curl-request,httpie-request,http-request,request-headers']
+operation::user/find-by-authenticated[snippets='curl-request,http-request']
 
 ==== Response
 operation::user/find-by-authenticated[snippets='http-response,response-fields']
 
-== 신원(Identity)
-회원의 본인인증 정보(실명, 전화번호)를 생성,조회 할 수 있습니다.
+== identity/v1/
+*신원(Identity)*
 
-=== ID로 IDENTITY 조회
-ID로  IDENTITY를 조회합니다.
+회원의 본인인증과 관련된 기능을 담당합니다.
 
-WARNING: `userId` 를 입력해야만 합니다.
+=== [POST] identity/me/send-code
+현재 사용자의 본인인증 코드를 SMS로 발신하는 엔드포인트입니다.
 
-==== Request
-operation::identity/find-by-user-id[snippets='curl-request,httpie-request,http-request,path-parameters']
-
-==== Response
-operation::identity/find-by-user-id[snippets='http-response,response-fields']
-
-=== 인증 중인 정보로 IDENTITY 조회
-현재 인증되어있는 사용자 정보로 신원을 조회합니다.
+Request Body에 담긴 휴대폰 전화번호로 본인인증 코드를 발신합니다.
 
 ==== Request
-operation::identity/find-by-authenticated[snippets='curl-request,httpie-request,http-request,request-headers']
+operation::identity/code/send-code[snippets='curl-request,http-request,request-body']
 
 ==== Response
-operation::identity/find-by-authenticated[snippets='http-response,response-fields']
 
-=== 인증 중인 정보로 IDENTITY 생성
-현재 인증되어있는 사용자 정보로 신원을 생성합니다.
+operation::identity/code/send-code[snippets='http-response']
+
+=== [POST - TEST ONLY] identity/me/send-code-test
+현재 사용자의 본인인증 코드를 SMS로 발신하고, 본인인증 코드를 가져오는 엔드포인트입니다.
+
+SMS로 인증코드를 확인받지 않고, Response 값에 본인인증 코드를 포함하여 반환됩니다.
+
+WARNING: 테스트 환경에서만 사용 가능합니다.
+
+==== Request
+operation::identity/code/send-code-test[snippets='curl-request,http-request,request-body']
+
+==== Response
+
+operation::identity/code/send-code-test[snippets='http-response']
+
+=== [GET] identity/me
+현재 사용자의 본인인증 정보를 가져오는 엔드포인트입니다.
+
+==== Request
+operation::identity/identity/find-by-authenticated[snippets='curl-request,http-request']
+
+==== Response
+operation::identity/identity/find-by-authenticated[snippets='http-response,response-fields']
+
+=== [POST] identity/me
+본인인증 코드와 개인정보를 입력받아서 `Identity`를 생성하는 엔드포인트입니다.
 
 사용자의 개인정보(본인인증 정보)를 등록하고 권한을 `인증된 유저(ROLE_USER)` 로 변경합니다.
 
 ==== Request
-operation::identity/create-by-authenticated[snippets='curl-request,httpie-request,http-request,request-body']
+operation::identity/identity/create-by-authenticated[snippets='curl-request,http-request,request-body']
 
 ==== Response
-사용자의 권한이 업데이트되어 세션 정보를 갱신하기 위해 로그아웃 URI로 리다이렉트됩니다.
+사용자의 권한이 변경되어 세션 정보를 갱신하기 위해 로그아웃 URI로 리다이렉트됩니다.
 
-operation::identity/create-by-authenticated[snippets='http-response']
+operation::identity/identity/create-by-authenticated[snippets='http-response']
+
+=== [POST] identity/{userID}
+USER ID를 사용하여 특정 사용자의 본인인증 정보를 가져오는 엔드포인트입니다.
+
+WARNING: `userId` 를 입력해야만 합니다.
+
+==== Request
+operation::identity/identity/find-by-user-id[snippets='curl-request,http-request,path-parameters']
+
+==== Response
+operation::identity/identity/find-by-user-id[snippets='http-response,response-fields']
+
+=== [PUT] identity/me
+현재 사용자의 본인인증 정보를 가져오는 엔드포인트입니다.
+
+==== Request
+operation::identity/identity/modify-by-authenticated[snippets='curl-request,http-request,request-body']
+
+==== Response
+사용자의 권한이 변경되어 세션 정보를 갱신하기 위해 로그아웃 URI로 리다이렉트됩니다.
+
+operation::identity/identity/modify-by-authenticated[snippets='http-response']
+
+== application/v1/
+*원서(Application)*
+
+=== Enum 정리
+
+==== EvaluationStatus
+시험 결과 상태
+[cols="2,3"]
+|====
+|Name |설명
+|`NOT_YET`|아직 시험 이전 시점
+|`PASS`|통과
+|`FALL`|탈락
+|====
+==== Gender
+성별
+[cols="2,3"]
+|====
+|Name |설명
+|`MALE`|남성
+|`FEMALE`|여성
+|====
+==== GraduationStatus
+졸업 상태
+[cols="2,3"]
+|====
+|Name |설명
+|`CANDIDATE`|졸업 예정
+|`GRADUATE`|졸업
+|`GED`|검정고시
+|====
+
+==== Major
+학과
+[cols="2,3"]
+|====
+|Name |설명
+|`AI`|AI 학과
+|`IOT`|IOT 학고
+|`SW`|SW 학과
+|====
+==== Screening
+입학 전형
+[cols="2,3"]
+|====
+|Name |설명
+|`GENERAL`|일반
+|`SOCIAL`|사회통합(특별)전형
+|`SPECIAL_VETERANS`| [전형 외 특별전형] 국가보훈대상자
+|`SPECIAL_ADMISSION`| [전형 외 특별전형] 특례입학대상자
+|====
+
+=== [GET] application/me
+현재 사용자의 원서 정보를 가져오는 엔드포인트입니다.
+
+==== Request
+operation::application/ged-read-me[snippets='curl-request,http-request']
+
+==== Response
+
+===== 검정고시(GED) 학생의 경우
+operation::application/ged-read-me[snippets='http-response,response-fields']
+
+===== 졸업 예정(CANDIDATE), 졸업(GRADUATE) 학생의 경우
+operation::application/general-read-me[snippets='http-response,response-fields']
+
+=== [GET] application/{userId}
+USER ID를 사용하여 특정 사용자의 원서 정보를 가져오는 엔드포인트입니다.
+
+==== Request
+operation::application/ged-read-one[snippets='curl-request,http-request']
+
+==== Response
+
+===== 검정고시(GED) 학생의 경우
+operation::application/ged-read-one[snippets='http-response,response-fields']
+
+===== 졸업 예정(CANDIDATE), 졸업(GRADUATE) 학생의 경우
+operation::application/general-read-one[snippets='http-response,response-fields']
+
+=== [POST] image
+현재 사용자의 증명사진을 등록하는 엔드포인트입니다.
+
+==== Request
+operation::application/upload-image[snippets='curl-request,http-request,request-parts']
+
+==== Response
+operation::application/upload-image[snippets='http-response,response-fields']
+
+=== [POST] application/me
+현재 사용자의 원서를 생성하는 엔드포인트입니다.
+
+==== Request
+operation::application/create[snippets='curl-request,http-request,request-fields']
+
+==== Response
+operation::application/create[snippets='http-response']
+
+=== [PUT] application/me
+현재 사용자의 원서를 수정하는 엔드포인트입니다.
+
+==== Request
+operation::application/modify[snippets='curl-request,http-request,request-fields']
+
+==== Response
+operation::application/modify[snippets='http-response']
+
+=== [DELETE] application/me
+현재 사용자의 원서를 삭제하는 엔드포인트입니다.
+
+==== Request
+operation::application/delete-application[snippets='curl-request,http-request']
+
+==== Response
+operation::application/delete-application[snippets='http-response']
+
+=== [GET] application/all
+모든 사용자의 원서를 조회하는 엔드포인트입니다.
+
+==== Request
+operation::application/find-all[snippets='curl-request,http-request,query-parameters']
+
+==== Response
+operation::application/delete-application[snippets='http-response']
+
+=== [PUT] status/{userId}
+USER ID를 사용하여 특정 사용자의 원서의 상태를 변경하는 엔드포인트입니다.
+
+==== Request
+operation::application/modify-status[snippets='curl-request,http-request,request-fields']
+
+==== Response
+operation::application/modify-status[snippets='http-response']
+
+=== [GET] final-submit
+현재 사용자의 원서를 최종제출하는 엔드포인트입니다.
+
+최종제출 이후 사용자의 원서의 수정/삭제는 불가능합니다. (``ADMIN``은 수정/삭제 가능)
+
+==== Request
+operation::application/final-submission[snippets='curl-request,http-request']
+
+==== Response
+operation::application/final-submission[snippets='http-response']
+
+=== [GET] tickets
+모든 사용자의 수험표 정보를 조회하는 엔드포인트입니다.
+
+==== Request
+operation::application/tickets[snippets='curl-request,http-request,query-parameters']
+
+==== Response
+operation::application/tickets[snippets='http-response,response-fields']

--- a/hellogsm-web/src/docs/asciidoc/index.adoc
+++ b/hellogsm-web/src/docs/asciidoc/index.adoc
@@ -138,6 +138,10 @@ USER ID를 사용하여 특정 사용자 정보를 가져오는 엔드포인트�
 
 WARNING: `userId` 를 입력해야만 합니다.
 
+==== 사용 가능한 권환
+    ROLE_ADMIN
+
+
 ==== Request
 operation::user/find-by-user-id[snippets='curl-request,http-request,path-parameters']
 
@@ -146,6 +150,9 @@ operation::user/find-by-user-id[snippets='http-response,response-fields']
 
 === [GET] user/me
 현재 사용자 정보를 가져오는 엔드포인트입니다.
+
+==== 사용 가능한 권환
+    ROLE_UNAUTHENTICATED, ROLE_USER
 
 ==== Request
 operation::user/find-by-authenticated[snippets='curl-request,http-request']
@@ -163,6 +170,9 @@ operation::user/find-by-authenticated[snippets='http-response,response-fields']
 
 Request Body에 담긴 휴대폰 전화번호로 본인인증 코드를 발신합니다.
 
+==== 사용 가능한 권환
+    ROLE_UNAUTHENTICATED, ROLE_USER
+
 ==== Request
 operation::identity/code/send-code[snippets='curl-request,http-request,request-body']
 
@@ -177,6 +187,9 @@ SMS로 인증코드를 확인받지 않고, Response 값에 본인인증 코드�
 
 WARNING: 테스트 환경에서만 사용 가능합니다.
 
+==== 사용 가능한 권환
+    ROLE_UNAUTHENTICATED, ROLE_USER
+
 ==== Request
 operation::identity/code/send-code-test[snippets='curl-request,http-request,request-body']
 
@@ -187,6 +200,9 @@ operation::identity/code/send-code-test[snippets='http-response']
 === [GET] identity/me
 현재 사용자의 본인인증 정보를 가져오는 엔드포인트입니다.
 
+==== 사용 가능한 권환
+    ROLE_USER
+
 ==== Request
 operation::identity/identity/find-by-authenticated[snippets='curl-request,http-request']
 
@@ -194,9 +210,12 @@ operation::identity/identity/find-by-authenticated[snippets='curl-request,http-r
 operation::identity/identity/find-by-authenticated[snippets='http-response,response-fields']
 
 === [POST] identity/me
-본인인증 코드와 개인정보를 입력받아서 `Identity`를 생성하는 엔드포인트입니다.
+본인인증 코드와 개인정보를 입력받아서 `Identity` 를 생성하는 엔드포인트입니다.
 
 사용자의 개인정보(본인인증 정보)를 등록하고 권한을 `인증된 유저(ROLE_USER)` 로 변경합니다.
+
+==== 사용 가능한 권환
+    ROLE_UNAUTHENTICATED, ROLE_USER
 
 ==== Request
 operation::identity/identity/create-by-authenticated[snippets='curl-request,http-request,request-body']
@@ -206,10 +225,13 @@ operation::identity/identity/create-by-authenticated[snippets='curl-request,http
 
 operation::identity/identity/create-by-authenticated[snippets='http-response']
 
-=== [POST] identity/{userID}
+=== [GET] identity/{userID}
 USER ID를 사용하여 특정 사용자의 본인인증 정보를 가져오는 엔드포인트입니다.
 
 WARNING: `userId` 를 입력해야만 합니다.
+
+==== 사용 가능한 권환
+    ROLE_ADMIN
 
 ==== Request
 operation::identity/identity/find-by-user-id[snippets='curl-request,http-request,path-parameters']
@@ -218,7 +240,10 @@ operation::identity/identity/find-by-user-id[snippets='curl-request,http-request
 operation::identity/identity/find-by-user-id[snippets='http-response,response-fields']
 
 === [PUT] identity/me
-현재 사용자의 본인인증 정보를 가져오는 엔드포인트입니다.
+현재 사용자의 본인인증 정보를 수정하는 엔드포인트입니다.
+
+==== 사용 가능한 권환
+    ROLE_USER
 
 ==== Request
 operation::identity/identity/modify-by-authenticated[snippets='curl-request,http-request,request-body']
@@ -283,6 +308,9 @@ operation::identity/identity/modify-by-authenticated[snippets='http-response']
 === [GET] application/me
 현재 사용자의 원서 정보를 가져오는 엔드포인트입니다.
 
+==== 사용 가능한 권환
+    ROLE_USER
+
 ==== Request
 operation::application/ged-read-me[snippets='curl-request,http-request']
 
@@ -296,6 +324,9 @@ operation::application/general-read-me[snippets='http-response,response-fields']
 
 === [GET] application/{userId}
 USER ID를 사용하여 특정 사용자의 원서 정보를 가져오는 엔드포인트입니다.
+
+==== 사용 가능한 권환
+    ROLE_ADMIN
 
 ==== Request
 operation::application/ged-read-one[snippets='curl-request,http-request']
@@ -311,6 +342,9 @@ operation::application/general-read-one[snippets='http-response,response-fields'
 === [POST] image
 현재 사용자의 증명사진을 등록하는 엔드포인트입니다.
 
+==== 사용 가능한 권환
+    ROLE_USER
+
 ==== Request
 operation::application/upload-image[snippets='curl-request,http-request,request-parts']
 
@@ -319,6 +353,9 @@ operation::application/upload-image[snippets='http-response,response-fields']
 
 === [POST] application/me
 현재 사용자의 원서를 생성하는 엔드포인트입니다.
+
+==== 사용 가능한 권환
+    ROLE_USER
 
 ==== Request
 operation::application/create[snippets='curl-request,http-request,request-fields']
@@ -329,6 +366,9 @@ operation::application/create[snippets='http-response']
 === [PUT] application/me
 현재 사용자의 원서를 수정하는 엔드포인트입니다.
 
+==== 사용 가능한 권환
+    ROLE_USER
+
 ==== Request
 operation::application/modify[snippets='curl-request,http-request,request-fields']
 
@@ -337,6 +377,9 @@ operation::application/modify[snippets='http-response']
 
 === [DELETE] application/me
 현재 사용자의 원서를 삭제하는 엔드포인트입니다.
+
+==== 사용 가능한 권환
+    ROLE_USER
 
 ==== Request
 operation::application/delete-application[snippets='curl-request,http-request']
@@ -347,6 +390,9 @@ operation::application/delete-application[snippets='http-response']
 === [GET] application/all
 모든 사용자의 원서를 조회하는 엔드포인트입니다.
 
+==== 사용 가능한 권환
+    ROLE_ADMIN
+
 ==== Request
 operation::application/find-all[snippets='curl-request,http-request,query-parameters']
 
@@ -356,16 +402,24 @@ operation::application/delete-application[snippets='http-response']
 === [PUT] status/{userId}
 USER ID를 사용하여 특정 사용자의 원서의 상태를 변경하는 엔드포인트입니다.
 
+==== 사용 가능한 권환
+    ROLE_ADMIN
+
+
 ==== Request
 operation::application/modify-status[snippets='curl-request,http-request,request-fields']
 
 ==== Response
 operation::application/modify-status[snippets='http-response']
 
-=== [GET] final-submit
+=== [PUT] final-submit
 현재 사용자의 원서를 최종제출하는 엔드포인트입니다.
 
-최종제출 이후 사용자의 원서의 수정/삭제는 불가능합니다. (``ADMIN``은 수정/삭제 가능)
+최종제출 이후 사용자의 원서의 수정/삭제는 불가능합니다. (``ADMIN``은 수정 가능)
+
+==== 사용 가능한 권환
+    ROLE_USER
+
 
 ==== Request
 operation::application/final-submission[snippets='curl-request,http-request']
@@ -375,6 +429,9 @@ operation::application/final-submission[snippets='http-response']
 
 === [GET] tickets
 모든 사용자의 수험표 정보를 조회하는 엔드포인트입니다.
+
+==== 사용 가능한 권환
+    ROLE_ADMIN
 
 ==== Request
 operation::application/tickets[snippets='curl-request,http-request,query-parameters']

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.cookies.RequestCookiesSnippet;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,6 +35,7 @@ import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationSta
 import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplicationRes;
 import team.themoment.hellogsm.web.domain.application.dto.response.TicketResDto;
 import team.themoment.hellogsm.web.domain.application.service.*;
+import team.themoment.hellogsm.web.domain.common.ControllerTestUtil;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 import java.math.BigDecimal;
@@ -308,7 +310,7 @@ class ApplicationControllerTest {
                 .andExpect(jsonPath("$.admissionGrade.gedMaxScore").value(admissionGrade.gedMaxScore()))
                 .andDo(this.documentationHandler.document(
                         pathParameters(parameterWithName("userId").description("조회하고자 하는 USER의 식별자")),
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                        ControllerTestUtil.requestSessionCookie(),
                         responseFields(
                                 Stream.concat(
                                         Arrays.stream(applicationCommonResponseFields),
@@ -355,7 +357,7 @@ class ApplicationControllerTest {
                 .andExpect(jsonPath("$.admissionGrade.extracurricularSubtotalScore").value(admissionGrade.extracurricularSubtotalScore()))
                 .andDo(this.documentationHandler.document(
                                 pathParameters(parameterWithName("userId").description("조회하고자 하는 USER의 식별자")),
-                                requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                                ControllerTestUtil.requestSessionCookie(),
                                 responseFields(
                                         Stream.concat(
                                                 Arrays.stream(applicationCommonResponseFields),
@@ -454,7 +456,7 @@ class ApplicationControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andDo(this.documentationHandler.document(
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                        ControllerTestUtil.requestSessionCookie(),
                         requestFields(createRequestFields)
                 ));
     }
@@ -471,7 +473,7 @@ class ApplicationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andDo(this.documentationHandler.document(
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                        ControllerTestUtil.requestSessionCookie(),
                         requestFields(createRequestFields)
                 ));
     }
@@ -529,7 +531,7 @@ class ApplicationControllerTest {
                                 parameterWithName("page").description("페이지"),
                                 parameterWithName("size").description("원서 크기")
                         ),
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                        ControllerTestUtil.requestSessionCookie(),
                         responseFields(
                                 fieldWithPath("info.count").type(NUMBER).description("원서 개수"),
                                 fieldWithPath("applications[].applicationId").type(NUMBER).description("원서 식별자"),
@@ -580,7 +582,7 @@ class ApplicationControllerTest {
                         pathParameters(
                                 parameterWithName("userId").description("유저 식별자")
                         ),
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                        ControllerTestUtil.requestSessionCookie(),
                         requestFields(
                                 fieldWithPath("isFinalSubmitted").type(BOOLEAN).description("최종제출 여부"),
                                 fieldWithPath("isPrintsArrived").type(BOOLEAN).description("서류 도착 여부"),

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -55,6 +55,7 @@ import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static team.themoment.hellogsm.web.domain.common.ControllerTestUtil.requestSessionCookie;
 
 @Tag("restDocsTest")
 @WebMvcTest(controllers = ApplicationController.class)
@@ -306,7 +307,7 @@ class ApplicationControllerTest {
                 .andExpect(jsonPath("$.admissionGrade.gedMaxScore").value(admissionGrade.gedMaxScore()))
                 .andDo(this.documentationHandler.document(
                         pathParameters(parameterWithName("userId").description("조회하고자 하는 USER의 식별자")),
-                        ControllerTestUtil.requestSessionCookie(),
+                        requestSessionCookie(),
                         responseFields(
                                 Stream.concat(
                                         Arrays.stream(applicationCommonResponseFields),
@@ -353,7 +354,7 @@ class ApplicationControllerTest {
                 .andExpect(jsonPath("$.admissionGrade.extracurricularSubtotalScore").value(admissionGrade.extracurricularSubtotalScore()))
                 .andDo(this.documentationHandler.document(
                                 pathParameters(parameterWithName("userId").description("조회하고자 하는 USER의 식별자")),
-                                ControllerTestUtil.requestSessionCookie(),
+                                requestSessionCookie(),
                                 responseFields(
                                         Stream.concat(
                                                 Arrays.stream(applicationCommonResponseFields),
@@ -452,7 +453,7 @@ class ApplicationControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andDo(this.documentationHandler.document(
-                        ControllerTestUtil.requestSessionCookie(),
+                        requestSessionCookie(),
                         requestFields(createRequestFields)
                 ));
     }
@@ -469,7 +470,7 @@ class ApplicationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andDo(this.documentationHandler.document(
-                        ControllerTestUtil.requestSessionCookie(),
+                        requestSessionCookie(),
                         requestFields(createRequestFields)
                 ));
     }
@@ -527,7 +528,7 @@ class ApplicationControllerTest {
                                 parameterWithName("page").description("페이지"),
                                 parameterWithName("size").description("원서 크기")
                         ),
-                        ControllerTestUtil.requestSessionCookie(),
+                        requestSessionCookie(),
                         responseFields(
                                 fieldWithPath("info.count").type(NUMBER).description("원서 개수"),
                                 fieldWithPath("applications[].applicationId").type(NUMBER).description("원서 식별자"),
@@ -578,7 +579,7 @@ class ApplicationControllerTest {
                         pathParameters(
                                 parameterWithName("userId").description("유저 식별자")
                         ),
-                        ControllerTestUtil.requestSessionCookie(),
+                        requestSessionCookie(),
                         requestFields(
                                 fieldWithPath("isFinalSubmitted").type(BOOLEAN).description("최종제출 여부"),
                                 fieldWithPath("isPrintsArrived").type(BOOLEAN).description("서류 도착 여부"),
@@ -605,7 +606,7 @@ class ApplicationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andDo(this.documentationHandler.document(
-                        ControllerTestUtil.requestSessionCookie()
+                        requestSessionCookie()
                 ));
     }
 
@@ -695,7 +696,7 @@ class ApplicationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andDo(this.documentationHandler.document(
-                        ControllerTestUtil.requestSessionCookie()
+                        requestSessionCookie()
                 ));
     }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -166,13 +166,13 @@ class ApplicationControllerTest {
             fieldWithPath("guardianPhoneNumber").type(STRING).description("보호자 전화번호"),
             fieldWithPath("teacherName").type(STRING).description("지원자 선생님 이름"),
             fieldWithPath("teacherPhoneNumber").type(STRING).description("지원자 선생님 전화번호"),
-            fieldWithPath("firstDesiredMajor").type(enumAsString(Major.class)).description("1지망 학과"),
-            fieldWithPath("secondDesiredMajor").type(enumAsString(Major.class)).description("2지망 학과"),
-            fieldWithPath("thirdDesiredMajor").type(enumAsString(Major.class)).description("3지망 학과"),
+            fieldWithPath("firstDesiredMajor").type(STRING).description("1지망 학과"),
+            fieldWithPath("secondDesiredMajor").type(STRING).description("2지망 학과"),
+            fieldWithPath("thirdDesiredMajor").type(STRING).description("3지망 학과"),
             fieldWithPath("middleSchoolGrade").type(STRING).description("중학교 성적 json 형태로"),
             fieldWithPath("schoolName").type(STRING).description("지원자 학교 이름"),
             fieldWithPath("schoolLocation").type(STRING).description("지원자 학교 위치"),
-            fieldWithPath("screening").type(enumAsString(Screening.class)).description("지원 전형")
+            fieldWithPath("screening").type(STRING).description("지원 전형")
     };
 
 
@@ -584,14 +584,14 @@ class ApplicationControllerTest {
                         requestFields(
                                 fieldWithPath("isFinalSubmitted").type(BOOLEAN).description("최종제출 여부"),
                                 fieldWithPath("isPrintsArrived").type(BOOLEAN).description("서류 도착 여부"),
-                                fieldWithPath("firstEvaluation").type(enumAsString(EvaluationStatus.class)).description("1차 평과 결과"),
-                                fieldWithPath("secondEvaluation").type(enumAsString(EvaluationStatus.class)).description("2차 평과 결과"),
-                                fieldWithPath("screeningSubmittedAt").type(enumAsString(Screening.class)).description("최종제출 시 전형 상태"),
-                                fieldWithPath("screeningFirstEvaluationAt").type(enumAsString(Screening.class)).description("1차 평가 이후 전형 상태"),
-                                fieldWithPath("screeningSecondEvaluationAt").type(enumAsString(Screening.class)).description("2차 평가 이후 전형 상태"),
+                                fieldWithPath("firstEvaluation").type(STRING).description("1차 평과 결과"),
+                                fieldWithPath("secondEvaluation").type(STRING).description("2차 평과 결과"),
+                                fieldWithPath("screeningSubmittedAt").type(STRING).description("최종제출 시 전형 상태"),
+                                fieldWithPath("screeningFirstEvaluationAt").type(STRING).description("1차 평가 이후 전형 상태"),
+                                fieldWithPath("screeningSecondEvaluationAt").type(STRING).description("2차 평가 이후 전형 상태"),
                                 fieldWithPath("registrationNumber").type(NUMBER).description("접수 번호"),
                                 fieldWithPath("secondScore").type(NUMBER).description("2차 평가 점수"),
-                                fieldWithPath("finalMajor").type(enumAsString(Major.class)).description("최종 합격 전공")
+                                fieldWithPath("finalMajor").type(STRING).description("최종 합격 전공")
                         )
                 ));
     }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -55,6 +55,7 @@ import static org.springframework.restdocs.payload.JsonFieldType.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static team.themoment.hellogsm.web.domain.common.ControllerTestUtil.enumAsString;
 import static team.themoment.hellogsm.web.domain.common.ControllerTestUtil.requestSessionCookie;
 
 @Tag("restDocsTest")
@@ -124,7 +125,7 @@ class ApplicationControllerTest {
             fieldWithPath("admissionInfo.applicantBirth").type(STRING).description("지원자 생년월일"),
             fieldWithPath("admissionInfo.address").type(STRING).description("지원자 주소"),
             fieldWithPath("admissionInfo.detailAddress").type(STRING).description("지원자 상세 주소"),
-            fieldWithPath("admissionInfo.graduation").type(GraduationStatus.class).description("지원자 졸업 여부"),
+            fieldWithPath("admissionInfo.graduation").type(enumAsString(GraduationStatus.class)).description("지원자 졸업 여부"),
             fieldWithPath("admissionInfo.telephone").type(STRING).description("지원자 집전화"),
             fieldWithPath("admissionInfo.applicantPhoneNumber").type(STRING).description("지원자 전화 번호"),
             fieldWithPath("admissionInfo.guardianName").type(STRING).description("보호자 이름"),
@@ -135,23 +136,23 @@ class ApplicationControllerTest {
             fieldWithPath("admissionInfo.schoolName").type(STRING).description("지원자 중학교 이름"),
             fieldWithPath("admissionInfo.schoolLocation").type(STRING).description("지원자 학교 주소"),
             fieldWithPath("admissionInfo.applicantImageUri").type(STRING).description("지원자 증명사진"),
-            fieldWithPath("admissionInfo.desiredMajor.firstDesiredMajor").type(STRING).description("지원자 1지망 학과"),
-            fieldWithPath("admissionInfo.desiredMajor.secondDesiredMajor").type(STRING).description("지원자 2지망 학과"),
-            fieldWithPath("admissionInfo.desiredMajor.thirdDesiredMajor").type(STRING).description("지원자 3지망 학과"),
-            fieldWithPath("admissionInfo.screening").type(Screening.class).description("지원 전형"),
+            fieldWithPath("admissionInfo.desiredMajor.firstDesiredMajor").type(enumAsString(Major.class)).description("지원자 1지망 학과"),
+            fieldWithPath("admissionInfo.desiredMajor.secondDesiredMajor").type(enumAsString(Major.class)).description("지원자 2지망 학과"),
+            fieldWithPath("admissionInfo.desiredMajor.thirdDesiredMajor").type(enumAsString(Major.class)).description("지원자 3지망 학과"),
+            fieldWithPath("admissionInfo.screening").type(enumAsString(Screening.class)).description("지원 전형"),
 
             fieldWithPath("middleSchoolGrade").type(STRING).description("중학교 점수가 json 문자열 형태로 되어있음"),
 
             fieldWithPath("admissionStatus.isFinalSubmitted").type(BOOLEAN).description("최종 제출 여부"),
             fieldWithPath("admissionStatus.isPrintsArrived").type(BOOLEAN).description("서류 도착 여부"),
-            fieldWithPath("admissionStatus.firstEvaluation").type(STRING).description("첫 번째 시험 평가 결과"),
-            fieldWithPath("admissionStatus.secondEvaluation").type(STRING).description("두 번째 시험 평가 결과"),
-            fieldWithPath("admissionStatus.screeningSubmittedAt").type(STRING).description("최종제출 시 전형 상태").optional(),
-            fieldWithPath("admissionStatus.screeningFirstEvaluationAt").type(STRING).description("1차 평가 이후 전형 상태").optional(),
-            fieldWithPath("admissionStatus.screeningSecondEvaluationAt").type(STRING).description("2차 평가 이후 전형 상태").optional(),
+            fieldWithPath("admissionStatus.firstEvaluation").type(enumAsString(EvaluationStatus.class)).description("첫 번째 시험 평가 결과"),
+            fieldWithPath("admissionStatus.secondEvaluation").type(enumAsString(EvaluationStatus.class)).description("두 번째 시험 평가 결과"),
+            fieldWithPath("admissionStatus.screeningSubmittedAt").type(enumAsString(Screening.class)).description("최종제출 시 전형 상태").optional(),
+            fieldWithPath("admissionStatus.screeningFirstEvaluationAt").type(enumAsString(Screening.class)).description("1차 평가 이후 전형 상태").optional(),
+            fieldWithPath("admissionStatus.screeningSecondEvaluationAt").type(enumAsString(Screening.class)).description("2차 평가 이후 전형 상태").optional(),
             fieldWithPath("admissionStatus.registrationNumber").type(NUMBER).description("접수 번호").optional(),
             fieldWithPath("admissionStatus.secondScore").type(NUMBER).description("2차 점수").optional(),
-            fieldWithPath("admissionStatus.finalMajor").type(STRING).description("최종 학과").optional()
+            fieldWithPath("admissionStatus.finalMajor").type(enumAsString(Major.class)).description("최종 학과").optional()
     };
 
     protected final FieldDescriptor[] createRequestFields = new FieldDescriptor[]{
@@ -165,13 +166,13 @@ class ApplicationControllerTest {
             fieldWithPath("guardianPhoneNumber").type(STRING).description("보호자 전화번호"),
             fieldWithPath("teacherName").type(STRING).description("지원자 선생님 이름"),
             fieldWithPath("teacherPhoneNumber").type(STRING).description("지원자 선생님 전화번호"),
-            fieldWithPath("firstDesiredMajor").type(STRING).description("1지망 학과"),
-            fieldWithPath("secondDesiredMajor").type(STRING).description("2지망 학과"),
-            fieldWithPath("thirdDesiredMajor").type(STRING).description("3지망 학과"),
+            fieldWithPath("firstDesiredMajor").type(enumAsString(Major.class)).description("1지망 학과"),
+            fieldWithPath("secondDesiredMajor").type(enumAsString(Major.class)).description("2지망 학과"),
+            fieldWithPath("thirdDesiredMajor").type(enumAsString(Major.class)).description("3지망 학과"),
             fieldWithPath("middleSchoolGrade").type(STRING).description("중학교 성적 json 형태로"),
             fieldWithPath("schoolName").type(STRING).description("지원자 학교 이름"),
             fieldWithPath("schoolLocation").type(STRING).description("지원자 학교 위치"),
-            fieldWithPath("screening").type(STRING).description("지원 전형")
+            fieldWithPath("screening").type(enumAsString(Screening.class)).description("지원 전형")
     };
 
 
@@ -540,11 +541,11 @@ class ApplicationControllerTest {
                                 fieldWithPath("applications[].teacherPhoneNumber").type(STRING).description("선생님 전화번호"),
                                 fieldWithPath("applications[].isFinalSubmitted").type(BOOLEAN).description("최종 제출 여부"),
                                 fieldWithPath("applications[].isPrintsArrived").type(BOOLEAN).description("서류 도착 여부"),
-                                fieldWithPath("applications[].firstEvaluation").type(STRING).description("1차 평가 결과"),
-                                fieldWithPath("applications[].secondEvaluation").type(STRING).description("2차 평가 결과"),
-                                fieldWithPath("applications[].screeningSubmittedAt").type(STRING).description("최종제출 시 전형 상태"),
-                                fieldWithPath("applications[].screeningFirstEvaluationAt").type(STRING).description("1차 평가 이후 전형 상태"),
-                                fieldWithPath("applications[]screeningSecondEvaluationAt").type(STRING).description("2차 평가 이후 전형 상태"),
+                                fieldWithPath("applications[].firstEvaluation").type(enumAsString(EvaluationStatus.class)).description("1차 평가 결과"),
+                                fieldWithPath("applications[].secondEvaluation").type(enumAsString(EvaluationStatus.class)).description("2차 평가 결과"),
+                                fieldWithPath("applications[].screeningSubmittedAt").type(enumAsString(Screening.class)).description("최종제출 시 전형 상태"),
+                                fieldWithPath("applications[].screeningFirstEvaluationAt").type(enumAsString(Screening.class)).description("1차 평가 이후 전형 상태"),
+                                fieldWithPath("applications[]screeningSecondEvaluationAt").type(enumAsString(Screening.class)).description("2차 평가 이후 전형 상태"),
                                 fieldWithPath("applications[].registrationNumber").type(NUMBER).description("접수 번호"),
                                 fieldWithPath("applications[].secondScore").type(STRING).description("2차 시험 점수")
                         )
@@ -583,14 +584,14 @@ class ApplicationControllerTest {
                         requestFields(
                                 fieldWithPath("isFinalSubmitted").type(BOOLEAN).description("최종제출 여부"),
                                 fieldWithPath("isPrintsArrived").type(BOOLEAN).description("서류 도착 여부"),
-                                fieldWithPath("firstEvaluation").type(STRING).description("1차 평과 결과"),
-                                fieldWithPath("secondEvaluation").type(STRING).description("2차 평과 결과"),
-                                fieldWithPath("screeningSubmittedAt").type(STRING).description("최종제출 시 전형 상태"),
-                                fieldWithPath("screeningFirstEvaluationAt").type(STRING).description("1차 평가 이후 전형 상태"),
-                                fieldWithPath("screeningSecondEvaluationAt").type(STRING).description("2차 평가 이후 전형 상태"),
+                                fieldWithPath("firstEvaluation").type(enumAsString(EvaluationStatus.class)).description("1차 평과 결과"),
+                                fieldWithPath("secondEvaluation").type(enumAsString(EvaluationStatus.class)).description("2차 평과 결과"),
+                                fieldWithPath("screeningSubmittedAt").type(enumAsString(Screening.class)).description("최종제출 시 전형 상태"),
+                                fieldWithPath("screeningFirstEvaluationAt").type(enumAsString(Screening.class)).description("1차 평가 이후 전형 상태"),
+                                fieldWithPath("screeningSecondEvaluationAt").type(enumAsString(Screening.class)).description("2차 평가 이후 전형 상태"),
                                 fieldWithPath("registrationNumber").type(NUMBER).description("접수 번호"),
                                 fieldWithPath("secondScore").type(NUMBER).description("2차 평가 점수"),
-                                fieldWithPath("finalMajor").type(STRING).description("최종 합격 전공")
+                                fieldWithPath("finalMajor").type(enumAsString(Major.class)).description("최종 합격 전공")
                         )
                 ));
     }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -194,10 +194,6 @@ class ApplicationControllerTest {
             "GENERAL"
     );
 
-
-    ApplicationControllerTest() {
-    }
-
     @BeforeEach
     void setUp(RestDocumentationContextProvider restDocumentation) {
         this.documentationHandler = document("application/{method-name}",

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -605,7 +605,7 @@ class ApplicationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andDo(this.documentationHandler.document(
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다."))
+                        ControllerTestUtil.requestSessionCookie()
                 ));
     }
 
@@ -695,7 +695,7 @@ class ApplicationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andDo(this.documentationHandler.document(
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다."))
+                        ControllerTestUtil.requestSessionCookie()
                 ));
     }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/common/ControllerTestUtil.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/common/ControllerTestUtil.java
@@ -1,0 +1,12 @@
+package team.themoment.hellogsm.web.domain.common;
+
+import org.springframework.restdocs.cookies.RequestCookiesSnippet;
+
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+
+public class ControllerTestUtil {
+    public static RequestCookiesSnippet requestSessionCookie() {
+        return requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다."));
+    }
+}

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/common/ControllerTestUtil.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/common/ControllerTestUtil.java
@@ -9,4 +9,12 @@ public class ControllerTestUtil {
     public static RequestCookiesSnippet requestSessionCookie() {
         return requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다."));
     }
+
+    public static String enumAsString(Class<? extends Enum<?>> enumClass) {
+        Enum<?>[] enumConstants = enumClass.getEnumConstants();
+        if (enumConstants != null && enumConstants.length > 0) {
+            return "[Enum] " + enumClass.getSimpleName();
+        }
+        return "";
+    }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/CodeControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/CodeControllerTest.java
@@ -79,7 +79,7 @@ class CodeControllerTest {
                         .content(this.objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다."))
+                        ControllerTestUtil.requestSessionCookie()
                 ));
     }
 
@@ -98,7 +98,7 @@ class CodeControllerTest {
                         .content(this.objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다."))
+                        ControllerTestUtil.requestSessionCookie()
                 ));
     }
 
@@ -117,7 +117,7 @@ class CodeControllerTest {
                         .content(this.objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다."))
+                        ControllerTestUtil.requestSessionCookie()
                 ));
     }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/CodeControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/CodeControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static team.themoment.hellogsm.web.domain.common.ControllerTestUtil.requestSessionCookie;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -32,6 +33,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import jakarta.servlet.http.Cookie;
+import team.themoment.hellogsm.web.domain.common.ControllerTestUtil;
 import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeReqDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsm.web.domain.identity.service.AuthenticateCodeService;
@@ -79,7 +81,7 @@ class CodeControllerTest {
                         .content(this.objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
-                        ControllerTestUtil.requestSessionCookie()
+                        requestSessionCookie()
                 ));
     }
 
@@ -98,7 +100,7 @@ class CodeControllerTest {
                         .content(this.objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
-                        ControllerTestUtil.requestSessionCookie()
+                        requestSessionCookie()
                 ));
     }
 
@@ -117,7 +119,7 @@ class CodeControllerTest {
                         .content(this.objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
-                        ControllerTestUtil.requestSessionCookie()
+                        requestSessionCookie()
                 ));
     }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
@@ -80,7 +80,7 @@ class IdentityControllerTest {
             fieldWithPath("name").type(STRING).description("USER의 이름"),
             fieldWithPath("phoneNumber").type(STRING).description("USER의 휴대전화 번호"),
             fieldWithPath("birth").type(STRING).description("USER의 생년월일"),
-            fieldWithPath("gender").type(Gender.class).description("USER의 성별"),
+            fieldWithPath("gender").type(enumAsString(Gender.class)).description("USER의 성별"),
             fieldWithPath("userId").type(NUMBER).description("USER 식별자")
     };
 

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import team.themoment.hellogsm.entity.domain.application.enums.Gender;
+import team.themoment.hellogsm.web.domain.common.ControllerTestUtil;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
@@ -112,7 +113,7 @@ class IdentityControllerTest {
         identityDtoPerform(get("/identity/v1/identity/me")
                 .cookie(new Cookie("SESSION", "SESSIONID12345")))
                 .andDo(this.documentationHandler.document(
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                        ControllerTestUtil.requestSessionCookie(),
                         responseFields(identityResponseFields)
                 ));
     }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
@@ -148,7 +148,7 @@ class IdentityControllerTest {
                         .content(this.objectMapper.writeValueAsString(request)))
                 .andExpect(status().isSeeOther())
                 .andDo(this.documentationHandler.document(
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다."))
+                        ControllerTestUtil.requestSessionCookie()
                 ));
     }
 
@@ -170,7 +170,7 @@ class IdentityControllerTest {
                         .content(this.objectMapper.writeValueAsString(request)))
                 .andExpect(status().isSeeOther())
                 .andDo(this.documentationHandler.document(
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다."))
+                        ControllerTestUtil.requestSessionCookie()
                 ));
     }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
@@ -80,7 +80,7 @@ class IdentityControllerTest {
             fieldWithPath("name").type(STRING).description("USER의 이름"),
             fieldWithPath("phoneNumber").type(STRING).description("USER의 휴대전화 번호"),
             fieldWithPath("birth").type(STRING).description("USER의 생년월일"),
-            fieldWithPath("gender").type(STRING).description("USER의 성별"),
+            fieldWithPath("gender").type(Gender.class).description("USER의 성별"),
             fieldWithPath("userId").type(NUMBER).description("USER 식별자")
     };
 

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
@@ -34,8 +34,6 @@ import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager
 import java.time.LocalDate;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
-import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
@@ -46,6 +44,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static team.themoment.hellogsm.web.domain.common.ControllerTestUtil.enumAsString;
+import static team.themoment.hellogsm.web.domain.common.ControllerTestUtil.requestSessionCookie;
 
 @Tag("restDocsTest")
 @WebMvcTest(controllers = IdentityController.class)
@@ -113,7 +113,7 @@ class IdentityControllerTest {
         identityDtoPerform(get("/identity/v1/identity/me")
                 .cookie(new Cookie("SESSION", "SESSIONID12345")))
                 .andDo(this.documentationHandler.document(
-                        ControllerTestUtil.requestSessionCookie(),
+                        requestSessionCookie(),
                         responseFields(identityResponseFields)
                 ));
     }
@@ -148,7 +148,7 @@ class IdentityControllerTest {
                         .content(this.objectMapper.writeValueAsString(request)))
                 .andExpect(status().isSeeOther())
                 .andDo(this.documentationHandler.document(
-                        ControllerTestUtil.requestSessionCookie()
+                        requestSessionCookie()
                 ));
     }
 
@@ -170,7 +170,7 @@ class IdentityControllerTest {
                         .content(this.objectMapper.writeValueAsString(request)))
                 .andExpect(status().isSeeOther())
                 .andDo(this.documentationHandler.document(
-                        ControllerTestUtil.requestSessionCookie()
+                        requestSessionCookie()
                 ));
     }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
@@ -40,6 +40,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static team.themoment.hellogsm.web.domain.common.ControllerTestUtil.enumAsString;
 
 @Tag("restDocsTest")
 @WebMvcTest(controllers = UserController.class)
@@ -76,7 +77,7 @@ class UserControllerTest {
             fieldWithPath("id").type(NUMBER).description("USER 식별자"),
             fieldWithPath("provider").type(STRING).description("OAuth2 제공자"),
             fieldWithPath("providerId").type(STRING).description("OAuth2 제공자의 회원 식별자"),
-            fieldWithPath("role").type(Role.class).description("USER 권한")
+            fieldWithPath("role").type(enumAsString(Role.class)).description("USER 권한")
     };
 
     @Test

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
@@ -76,7 +76,7 @@ class UserControllerTest {
             fieldWithPath("id").type(NUMBER).description("USER 식별자"),
             fieldWithPath("provider").type(STRING).description("OAuth2 제공자"),
             fieldWithPath("providerId").type(STRING).description("OAuth2 제공자의 회원 식별자"),
-            fieldWithPath("role").type(STRING).description("USER 권한")
+            fieldWithPath("role").type(Role.class).description("USER 권한")
     };
 
     @Test

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/user/controller/UserControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
+import team.themoment.hellogsm.web.domain.common.ControllerTestUtil;
 import team.themoment.hellogsm.web.domain.identity.controller.IdentityController;
 import team.themoment.hellogsm.web.domain.user.dto.domain.UserDto;
 import team.themoment.hellogsm.web.domain.user.service.UserByIdQuery;
@@ -95,7 +96,7 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.providerId").value(user.providerId()))
                 .andExpect(jsonPath("$.role").value(user.role().name()))
                 .andDo(this.documentationHandler.document(
-                        requestCookies(cookieWithName("SESSION").description("사용자의 SESSION ID, 브라우저로 접근 시 자동 생성됩니다.")),
+                        ControllerTestUtil.requestSessionCookie(),
                         responseFields(userResponseFields)
                 ));
     }


### PR DESCRIPTION
## 개요

controller 테스트코드에서 발생하는 중복, 비효율적인 부분을 보완하였습니다.
restdocs api 먕세서를 작성하였습니다.

## 본문

### 추가 

- ControllerTestUtil를 만들었습니다.
  - 반복되는 cookie 설명을 해소하기 위해 `enumAsString()` 메서드를 구현하고 적용하였습니다.
  - response 타입이 enum 클래스인 경우 type 설명에 패키지 명까지 포함되어 너무 긴 문제를 해결하기 위한 `requestSessionCookie()` 메서드를 추가/구현하였습니다.

### 변경 

- restdocs api 명세서에 추가된 테스트코드 설명 추가
