### PR TITLE
API 명세서 누락된 문서 추가 및 공백 제거

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ subprojects {
     }
 
     tasks.named('test') {
+        outputs.dir snippetsDir
         useJUnitPlatform()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,9 +33,4 @@ subprojects {
         /** for test **/
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
     }
-
-    tasks.named('test') {
-        outputs.dir snippetsDir
-        useJUnitPlatform()
-    }
 }

--- a/hellogsm-batch/build.gradle
+++ b/hellogsm-batch/build.gradle
@@ -9,3 +9,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.batch:spring-batch-test'
 }
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/hellogsm-entity/build.gradle
+++ b/hellogsm-entity/build.gradle
@@ -6,3 +6,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // @NotNull도 대체 가능하고, @AsserTrue도 대체 가능한데 일단 모듈 분리하는게 우선순위라 코드 수정 줄이기 위해 추가
 	implementation 'com.fasterxml.jackson.core:jackson-databind' //TODO 어플리케이션 Grade 리팩토링 할 때 지울 예정
 }
+
+tasks.named('test') {
+	useJUnitPlatform()
+}

--- a/hellogsm-web/build.gradle
+++ b/hellogsm-web/build.gradle
@@ -63,6 +63,11 @@ task restDocsTest(type: Test) {
     }
 }
 
+tasks.named('test') {
+    outputs.dir snippetsDir
+    useJUnitPlatform()
+}
+
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     configurations 'asciidoctorExt'

--- a/hellogsm-web/build.gradle
+++ b/hellogsm-web/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 bootJar {
     enabled = true
-    dependsOn asciidoctorw
+    dependsOn asciidoctor
     from ("${asciidoctor.outputDir}") {
         into 'static/docs'
     }

--- a/hellogsm-web/build.gradle
+++ b/hellogsm-web/build.gradle
@@ -2,7 +2,13 @@ plugins {
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
-bootJar { enabled = true }
+bootJar {
+    enabled = true
+    dependsOn asciidoctorw
+    from ("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
+}
 jar { enabled = true }
 
 ext {

--- a/hellogsm-web/src/docs/asciidoc/index.adoc
+++ b/hellogsm-web/src/docs/asciidoc/index.adoc
@@ -34,7 +34,7 @@ AsciiDoc 문법에 관한 내용은 link:https://docs.asciidoctor.org/asciidoc/l
 == API 서버 경로
 [cols="2,5,3"]
 |====
-|환경         |DNS |비고
+|환경     |DNS  |비고
 |작성중    | 입니다 |
 // |개발(dev)    | link:[https://dev-api.hellogsm.kr] |API 문서 제공
 // |운영(prod)   | link:[https://api.hellogsm.kr] | API 문서 미제공
@@ -116,6 +116,34 @@ CAUTION: 운영환경에 노출될 경우 보안 관련 문제가 발생할 수 
 
 = API 명세
 
+== auth/v1/
+*인증(Auth)*
+
+=== [GET] oauth2/authorization/{provider-name}
+
+해당 url로 접근 시 OAuth 페이지로 리다이렉트 됩니다.
+
+WARNING: API 요청을 보내지 않고, 직접 이동해야 합니다.
+
+==== Response
+
+OAuth2 인증 후, FE 메인페이지로 리다이렉트됩니다.
+
+==== `registrationId` 종류
+- google
+- github
+- kakao
+
+=== [GET] logout
+
+해당 url로 접근 시 로그아웃 됩니다.
+
+WARNING: API 요청을 보내지 않고, 직접 이동해야 합니다.
+
+==== Response
+
+로그아웃 이후, FE 메인페이지로 디라이렉트됩니다.
+
 == user/v1/
 *회원(User)*
 
@@ -165,6 +193,9 @@ operation::user/find-by-authenticated[snippets='http-response,response-fields']
 
 회원의 본인인증과 관련된 기능을 담당합니다.
 
+=== Enum 정리
+관련된 Enum 없음
+
 === [POST] identity/me/send-code
 현재 사용자의 본인인증 코드를 SMS로 발신하는 엔드포인트입니다.
 
@@ -177,7 +208,6 @@ Request Body에 담긴 휴대폰 전화번호로 본인인증 코드를 발신�
 operation::identity/code/send-code[snippets='curl-request,http-request,request-body']
 
 ==== Response
-
 operation::identity/code/send-code[snippets='http-response']
 
 === [POST - TEST ONLY] identity/me/send-code-test
@@ -194,8 +224,19 @@ WARNING: 테스트 환경에서만 사용 가능합니다.
 operation::identity/code/send-code-test[snippets='curl-request,http-request,request-body']
 
 ==== Response
-
 operation::identity/code/send-code-test[snippets='http-response']
+
+=== [POST] identity/me/auth-code
+휴대폰으로 발송된 인증코드를 인증하는 엔드포인트입니다.
+
+==== 사용 가능한 권환
+    ROLE_UNAUTHENTICATED, ROLE_USER
+
+==== Request
+operation::identity/code/auth-code[snippets='curl-request,http-request,request-body']
+
+==== Response
+operation::identity/code/auth-code[snippets='http-response']
 
 === [GET] identity/me
 현재 사용자의 본인인증 정보를 가져오는 엔드포인트입니다.
@@ -301,8 +342,8 @@ operation::identity/identity/modify-by-authenticated[snippets='http-response']
 |Name |설명
 |`GENERAL`|일반
 |`SOCIAL`|사회통합(특별)전형
-|`SPECIAL_VETERANS`| [전형 외 특별전형] 국가보훈대상자
-|`SPECIAL_ADMISSION`| [전형 외 특별전형] 특례입학대상자
+|`SPECIAL_VETERANS`| [정원 외 특별전형] 국가보훈대상자
+|`SPECIAL_ADMISSION`| [정원 외 특별전형] 특례입학대상자
 |====
 
 === [GET] application/me
@@ -315,7 +356,6 @@ operation::identity/identity/modify-by-authenticated[snippets='http-response']
 operation::application/ged-read-me[snippets='curl-request,http-request']
 
 ==== Response
-
 ===== 검정고시(GED) 학생의 경우
 operation::application/ged-read-me[snippets='http-response,response-fields']
 
@@ -332,7 +372,6 @@ USER ID를 사용하여 특정 사용자의 원서 정보를 가져오는 엔드
 operation::application/ged-read-one[snippets='curl-request,http-request']
 
 ==== Response
-
 ===== 검정고시(GED) 학생의 경우
 operation::application/ged-read-one[snippets='http-response,response-fields']
 

--- a/hellogsm-web/src/docs/asciidoc/index.adoc
+++ b/hellogsm-web/src/docs/asciidoc/index.adoc
@@ -29,13 +29,12 @@ v0.1, 2023-06-16
 
 AsciiDoc 문법에 관한 내용은 link:https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference[AsciiDoc Syntax Quick Reference]를 참고하시길 바랍니다.
 
-``API 명세``까지 아래 내용은 포멧을 보여주기 위한 임시 내용입니다. Hello,GSM의 명세가 아닙니다.
-
 == API 서버 경로
 [cols="2,5,3"]
 |====
 |환경     |DNS  |비고
-|작성중    | 입니다 |
+|Dev    | 아직 정해지지 않음 |
+|Prod    | 아직 정해지지 않음 |
 // |개발(dev)    | link:[https://dev-api.hellogsm.kr] |API 문서 제공
 // |운영(prod)   | link:[https://api.hellogsm.kr] | API 문서 미제공
 |====
@@ -96,9 +95,9 @@ CAUTION: 운영환경에 노출될 경우 보안 관련 문제가 발생할 수 
 |HttpStatus |설명
 |`OK(200)`|정상 응답
 |`CREATED(201)`|데이터가 새로(수정X) 추가된 경우
-|`SEE_OTHER(303)`|요청이 성공하였으며, 권한이 변경되어 로그아웃이 필요한 경우
+|`SEE_OTHER(303)`|FE 페이지로 이동하기 위해 리다이렉트 하는 경우
 |`BAD_REQUEST(400)`|요청값 누락, 잘못된 기입, 존재하지 않는 자료 요청
-|`FORBIDDEN(401)`|사용자를 식별이 불가능
+|`FORBIDDEN(401)`|사용자를 식별이 불가능힌 경우
 |`FORBIDDEN(403)`|사용자를 식별하였으나, 해당 사용자가 접근할 수 없는 요청(권한 없음)
 |`NOT_FOUND(404)`|존재하지 않는 엔드포인트
 |====


### PR DESCRIPTION
## 개요

API 명세서에 누락된 문서를 추가하였습니다.
test task를 root에서 각 모듈로 분리하였습니다.


## 본문
#### 추가한 내용
- 인증코드 인증 api
- OAuth 로그인 url
- 로그아웃 url

#### test task 분리 이유
web 모듈의 경우 restdocs를 사용하기 때문에 test task에 로직이 추가되어야 하는데, 다른 모듈을 그렇지 않아서 root에서 동일하게관리할 수 없었다.