### PR TITLE
OAuth 인증 handler 명확하게 변경

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -1,5 +1,10 @@
 package team.themoment.hellogsm.web.global.security;
 
+import org.springframework.security.web.authentication.ForwardAuthenticationFailureHandler;
+import org.springframework.security.web.authentication.ForwardAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
 import team.themoment.hellogsm.web.global.data.profile.ServerProfile;
 import team.themoment.hellogsm.web.global.security.auth.AuthEnvironment;
@@ -105,7 +110,8 @@ public class SecurityConfig {
                 oauth2Login
                         .authorizationEndpoint().baseUri(oauth2LoginEndpointBaseUri).and()
                         .loginProcessingUrl(oauth2LoginProcessingUri)
-                        .defaultSuccessUrl(authEnv.redirectBaseUri())
+                        .successHandler(new SimpleUrlAuthenticationSuccessHandler(authEnv.redirectBaseUri()))
+                        .failureHandler(new SimpleUrlAuthenticationFailureHandler(authEnv.redirectLoginFailureUri()))
 
         );
     }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthEnvironment.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthEnvironment.java
@@ -15,6 +15,7 @@ import java.util.List;
 @ConfigurationProperties(prefix = "auth")
 public record AuthEnvironment(
         String redirectBaseUri,
+        String redirectLoginFailureUri,
         List<String> allowedOrigins
 ) {
 }


### PR DESCRIPTION
## 개요

OAuth 설정 중 handler를 사용해서 리다이렉트 한다는게 명확하게 드러나도록 수정하였고, (내부적으로 기능을 동일함) 

만약 인증 실패 시, 인증 실패 페이지로 이동하도록 failureHandler()를 추가하였습니다.

### 기타
환경변수 추가되면서 노션에 yml 파일 업데이트했으니 새로 받아야 합니다.