### PR TITLE
H2Console url 허용 설정 제거

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -63,7 +63,6 @@ public class SecurityConfig {
             oauth2Login(http);
             http.authorizeHttpRequests(
                     httpRequests -> httpRequests
-                            .requestMatchers(toH2Console()).permitAll()
                             .requestMatchers(HttpMethod.GET, "/identity/v1/identity/me/send-code-test")
                             .hasAnyRole(
                                     Role.ROLE_UNAUTHENTICATED.getRole(),


### PR DESCRIPTION
## 개요

H2Console 허용 설정이 dev, local 환경에서 적용되어 dev 환경에서 h2가 connect 되지 않아 에러가 발생하는 문제를 해결하였습니다.
특정 요청이 아닌 나머지 모든 요청에 대해서 permitAll을 사용하기 때문에 지워도 문제 없이 동작합니다.