### PR TITLE
웹 정적 파일에 대한 요청을 허용하는 설정 클래스 추가

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/WebResourceConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/WebResourceConfig.java
@@ -11,7 +11,7 @@ public class WebResourceConfig {
 
     @Configuration
     @Profile(ServerProfile.PROD)
-    public class LocalWebConfig implements WebMvcConfigurer {
+    public class ProdWebConfig implements WebMvcConfigurer {
         @Override
         public void addResourceHandlers(ResourceHandlerRegistry registry) {
             // 리소스 허용 X
@@ -21,7 +21,7 @@ public class WebResourceConfig {
 
     @Configuration
     @Profile({ServerProfile.DEV, ServerProfile.LOCAL})
-    public class ProdWebConfig implements WebMvcConfigurer {
+    public class LocalWebConfig implements WebMvcConfigurer {
         @Override
         public void addResourceHandlers(ResourceHandlerRegistry registry) {
             restdocs(registry);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/WebResourceConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/WebResourceConfig.java
@@ -1,0 +1,36 @@
+package team.themoment.hellogsm.web.global.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import team.themoment.hellogsm.web.global.data.profile.ServerProfile;
+
+@Configuration
+public class WebResourceConfig {
+
+    @Configuration
+    @Profile(ServerProfile.PROD)
+    public class LocalWebConfig implements WebMvcConfigurer {
+        @Override
+        public void addResourceHandlers(ResourceHandlerRegistry registry) {
+            // 리소스 허용 X
+        }
+
+    }
+
+    @Configuration
+    @Profile({ServerProfile.DEV, ServerProfile.LOCAL})
+    public class ProdWebConfig implements WebMvcConfigurer {
+        @Override
+        public void addResourceHandlers(ResourceHandlerRegistry registry) {
+            restdocs(registry);
+        }
+    }
+
+    private void restdocs(ResourceHandlerRegistry registry) {
+        registry
+                .addResourceHandler("/docs/{index:index}.html")
+                .addResourceLocations("classpath:/static/docs/");
+    }
+}


### PR DESCRIPTION
## 개요

웹 정적 파일에 대한 요청을 허용하는 `WebResourceConfig` 객체를 정의하였습니다.

## 본문

dev, local의 경우만 접근 가능하고, prod 환경에서 접근이 불가능하도록 설정하였습니다.
