### PR TITLE
원서 성적 관련 엔티티 nullable false로 변경 및 ApplicationController 리턴 타입 변경

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGrade.java
@@ -13,7 +13,7 @@ import java.math.BigDecimal;
  * @since 1.0.0
  */
 @Entity
-@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GedAdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GedAdmissionGrade.java
@@ -32,11 +32,11 @@ import static lombok.AccessLevel.PROTECTED;
 @SuperBuilder
 @ToString
 public class GedAdmissionGrade extends AdmissionGrade {
-    @Column(name = "ged_total_score", nullable = true)
+    @Column(name = "ged_total_score", nullable = false)
     private BigDecimal gedTotalScore;
 
 
-    @Column(name = "ged_max_score", nullable = true)
+    @Column(name = "ged_max_score", nullable = false)
     private BigDecimal gedMaxScore;
 
     public GedAdmissionGrade(MiddleSchoolGrade middleSchoolGrade) {

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
@@ -30,43 +30,43 @@ import java.util.stream.Stream;
 public class GraduateAdmissionGrade extends AdmissionGrade {
 
 
-    @Column(name = "grade_1_semester_1_score", nullable = true)
+    @Column(name = "grade_1_semester_1_score", nullable = false)
     private BigDecimal grade1Semester1Score;  // 1 grade 1 semester 점수
 
 
-    @Column(name = "grade_1_semester_2_score", nullable = true)
+    @Column(name = "grade_1_semester_2_score", nullable = false)
     private BigDecimal grade1Semester2Score;
 
 
-    @Column(name = "grade_2_semester_1_score", nullable = true)
+    @Column(name = "grade_2_semester_1_score", nullable = false)
     private BigDecimal grade2Semester1Score;
 
 
-    @Column(name = "grade_2_semester_2_score", nullable = true)
+    @Column(name = "grade_2_semester_2_score", nullable = false)
     private BigDecimal grade2Semester2Score;
 
 
-    @Column(name = "grade_3_semester_1_score", nullable = true)
+    @Column(name = "grade_3_semester_1_score", nullable = false)
     private BigDecimal grade3Semester1Score;
 
 
-    @Column(name = "artistic_score", nullable = true)
+    @Column(name = "artistic_score", nullable = false)
     private BigDecimal artisticScore;
 
 
-    @Column(name = "curricular_subtotal_score", nullable = true)
+    @Column(name = "curricular_subtotal_score", nullable = false)
     private BigDecimal curricularSubtotalScore;
 
 
-    @Column(name = "attendance_score", nullable = true)
+    @Column(name = "attendance_score", nullable = false)
     private BigDecimal attendanceScore;
 
 
-    @Column(name = "volunteer_score")
+    @Column(name = "volunteer_score", nullable = false)
     private BigDecimal volunteerScore;
 
 
-    @Column(name = "extracurricular_subtotal_score")
+    @Column(name = "extracurricular_subtotal_score", nullable = false)
     private BigDecimal extracurricularSubtotalScore;
 
     public GraduateAdmissionGrade(MiddleSchoolGrade middleSchoolGrade) {

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
@@ -19,11 +19,11 @@ public class MiddleSchoolGrade {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "middle_school_grade_id")
+    @Column(name = "middle_school_grade_id", nullable = false)
     private Long id;
 
     @Lob
-    @Column(name = "middle_school_grade_text")
+    @Column(name = "middle_school_grade_text", nullable = false)
     private String middleSchoolGradeText;
 
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -46,13 +46,13 @@ public class ApplicationController {
     private final FinalSubmissionService finalSubmissionService;
 
     @GetMapping("/application/{userId}")
-    public SingleApplicationRes readOne(@PathVariable("userId") Long userId) {
-        return querySingleApplicationService.execute(userId);
+    public ResponseEntity<SingleApplicationRes> readOne(@PathVariable("userId") Long userId) {
+        return ResponseEntity.status(HttpStatus.OK).body(querySingleApplicationService.execute(userId));
     }
 
     @GetMapping("/application/me")
-    public SingleApplicationRes readMe() {
-        return querySingleApplicationService.execute(manager.getId());
+    public ResponseEntity<SingleApplicationRes> readMe() {
+        return ResponseEntity.status(HttpStatus.OK).body(querySingleApplicationService.execute(manager.getId()));
     }
 
     @PostMapping("/application/me")
@@ -107,9 +107,9 @@ public class ApplicationController {
     }
 
     @PostMapping("/image")
-    public Map<String, String> uploadImage(@Valid @RequestPart(name = "file") MultipartFile multipartFile) {
+    public ResponseEntity<Map<String, String>> uploadImage(@Valid @RequestPart(name = "file") MultipartFile multipartFile) {
         String url = imageSaveService.execute(multipartFile);
-        return Map.of("url", url);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("url", url));
     }
 
     @PutMapping("/final-submit")


### PR DESCRIPTION
## 개요

원서 도메인의 성적 관련 엔티티의 필드가`nullable = false` 옵션을 가지도록 변경하였습니다.

## 본문

성능을 약간 낮추더라도 nullable 한 값을 가지지 않는 것이 관리면에서 이점이 있다고 판단하여 변경하게되었습니다.

### 변경

1. 슈퍼-서브 타입 엔티티의 구현 속성을 `SINGLE_TABLE`에서 `JOINED`로 변경하고, 
서브 엔티티의 모든 필드에 `nullable = false` 속성을 가지도록 변경하였습니다.

2. ApplicationController에서 모든 메서드가 ResponseEntity를 반환하도록 변경하였습니다.

### 기타 

