### PR TITLE
원서 도메인 Nullalbe field가 Optional을 반환하도록 변경

### DIFF
--- a/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/setRegistrationNumber/SetRegistrationNumberJobConfig.java
+++ b/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/setRegistrationNumber/SetRegistrationNumberJobConfig.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import team.themoment.hellogsm.entity.common.util.OptionalUtils;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
 import team.themoment.hellogsm.entity.domain.application.entity.status.AdmissionStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.Screening;
@@ -140,8 +141,8 @@ public class SetRegistrationNumberJobConfig {
                     .firstEvaluation(admissionStatus.getFirstEvaluation())
                     .secondEvaluation(admissionStatus.getSecondEvaluation())
                     .registrationNumber(null)
-                    .secondScore(admissionStatus.getSecondScore())
-                    .finalMajor(admissionStatus.getFinalMajor())
+                    .secondScore(OptionalUtils.fromOptional(admissionStatus.getSecondScore()))
+                    .finalMajor(OptionalUtils.fromOptional(admissionStatus.getFinalMajor()))
                     .build();
             return clearAdmissionStatus;
         };
@@ -162,8 +163,8 @@ public class SetRegistrationNumberJobConfig {
                     .firstEvaluation(admissionStatus.getFirstEvaluation())
                     .secondEvaluation(admissionStatus.getSecondEvaluation())
                     .registrationNumber(registrationNumber)
-                    .secondScore(admissionStatus.getSecondScore())
-                    .finalMajor(admissionStatus.getFinalMajor())
+                    .secondScore(OptionalUtils.fromOptional(admissionStatus.getSecondScore()))
+                    .finalMajor(OptionalUtils.fromOptional(admissionStatus.getFinalMajor()))
                     .build();
             return newAdmissionStatus;
         };

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/common/util/OptionalUtils.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/common/util/OptionalUtils.java
@@ -1,0 +1,11 @@
+package team.themoment.hellogsm.entity.common.util;
+
+import java.util.Optional;
+
+public class OptionalUtils {
+
+    public static <T> T fromOptional(Optional<T> optional) {
+        return optional.orElse( null );
+    }
+
+}

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
@@ -9,6 +9,7 @@ import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.Screening;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 /**
  * 입학 원서의 인적사항을 저장하는 Entity입니다.
@@ -100,6 +101,26 @@ public class AdmissionInfo {
     @AssertFalse(message = "DesiredMajor 가 null 임")
     private boolean isDesiredMajorNull() {
         return desiredMajor == null;
+    }
+
+    public Optional<String> getTelephone() {
+        return Optional.ofNullable(telephone);
+    }
+
+    public Optional<String> getSchoolName() {
+        return Optional.ofNullable(schoolName);
+    }
+
+    public Optional<String> getSchoolLocation() {
+        return Optional.ofNullable(schoolLocation);
+    }
+
+    public Optional<String> getTeacherName() {
+        return Optional.ofNullable(teacherName);
+    }
+
+    public Optional<String> getTeacherPhoneNumber() {
+        return Optional.ofNullable(teacherPhoneNumber);
     }
 
 }

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
@@ -8,6 +8,7 @@ import team.themoment.hellogsm.entity.domain.application.enums.Major;
 import team.themoment.hellogsm.entity.domain.application.enums.Screening;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 /**
  * 입학 원서의 상태를 저장하는 Entity입니다.
@@ -59,6 +60,30 @@ public class AdmissionStatus {
 
     @Column(name = "second_score", nullable = true) // TODO 이름 바꾸기 - 2차 시험 점수
     private BigDecimal secondScore;
+
+    public Optional<Screening> getScreeningSubmittedAt() {
+        return Optional.ofNullable(screeningSubmittedAt);
+    }
+
+    public Optional<Screening> getScreeningFirstEvaluationAt() {
+        return Optional.ofNullable(screeningFirstEvaluationAt);
+    }
+
+    public Optional<Screening> getScreeningSecondEvaluationAt() {
+        return Optional.ofNullable(screeningSecondEvaluationAt);
+    }
+
+    public Optional<Long> getRegistrationNumber() {
+        return Optional.ofNullable(registrationNumber);
+    }
+
+    public Optional<BigDecimal> getSecondScore() {
+        return Optional.ofNullable(secondScore);
+    }
+
+    public Optional<Major> getFinalMajor() {
+        return Optional.ofNullable(finalMajor);
+    }
 
     @Enumerated(EnumType.STRING)
     @Column(name = "final_major", nullable = true)

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -25,6 +25,7 @@ import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplica
 import team.themoment.hellogsm.web.domain.application.dto.response.TicketResDto;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
+import team.themoment.hellogsm.entity.common.util.OptionalUtils;
 
 import java.util.List;
 
@@ -32,7 +33,8 @@ import java.util.List;
         componentModel = "spring",
         unmappedSourcePolicy = ReportingPolicy.ERROR,
         unmappedTargetPolicy = ReportingPolicy.ERROR,
-        typeConversionPolicy = ReportingPolicy.WARN
+        typeConversionPolicy = ReportingPolicy.WARN,
+        uses = OptionalUtils.class
 )
 public interface ApplicationMapper {
     ApplicationMapper INSTANCE = Mappers.getMapper(ApplicationMapper.class);
@@ -212,12 +214,12 @@ public interface ApplicationMapper {
                 .isPrintsArrived(admissionStatus.isPrintsArrived())
                 .firstEvaluation(admissionStatus.getFirstEvaluation())
                 .secondEvaluation(admissionStatus.getSecondEvaluation())
-                .registrationNumber(admissionStatus.getRegistrationNumber())
-                .screeningSubmittedAt(admissionStatus.getScreeningSubmittedAt())
-                .screeningFirstEvaluationAt(admissionStatus.getScreeningFirstEvaluationAt())
-                .screeningSecondEvaluationAt(admissionStatus.getScreeningSecondEvaluationAt())
-                .secondScore(admissionStatus.getSecondScore())
-                .finalMajor(admissionStatus.getFinalMajor())
+                .registrationNumber(OptionalUtils.fromOptional(admissionStatus.getRegistrationNumber()))
+                .screeningSubmittedAt(OptionalUtils.fromOptional(admissionStatus.getScreeningSubmittedAt()))
+                .screeningFirstEvaluationAt(OptionalUtils.fromOptional(admissionStatus.getScreeningFirstEvaluationAt()))
+                .screeningSecondEvaluationAt(OptionalUtils.fromOptional(admissionStatus.getScreeningSecondEvaluationAt()))
+                .secondScore(OptionalUtils.fromOptional(admissionStatus.getSecondScore()))
+                .finalMajor(OptionalUtils.fromOptional(admissionStatus.getFinalMajor()))
                 .build();
     }
 


### PR DESCRIPTION
## 개요

원서 도메인의 field가 nullable 인 field는 Optional을 반환하도록 Getter를 변경하였습니다. 

## 본문

Null일 수 있는 field를 그냥 반환한다면 NPE가 발생할 수 있음을 알기 어렵기 때문에 Optional을 리턴하도록 변경하였습니다. 

### 추가

- mapper에서 반복되는 Optional 클래스 처리를 위한 OptionalUtils 구현

### 변경

- 원서 도메인에 해당되는 객체의 field 중 nullalbe인 field의 Getter 메서드의 리턴 타입을 Optional로 변경
- Getter 메서드의 리턴타입 변경으로 인한 mapper 변경
