### PR TITLE
본인인증, 로그인, 로그아웃과 관련된 Redirect 기능 수정

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -8,14 +8,17 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import team.themoment.hellogsm.entity.domain.user.enums.Role;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.dto.response.CreateIdentityResDto;
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
 import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
 import team.themoment.hellogsm.web.domain.identity.service.ModifyIdentityService;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 import java.net.URI;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/identity/v1")
@@ -40,11 +43,9 @@ public class IdentityController {
     public ResponseEntity<Object> create(
             @RequestBody @Valid IdentityReqDto reqDto
     ) {
-        createIdentityService.execute(reqDto, manager.getId());
-        HttpHeaders headers = new HttpHeaders();
-        headers.setLocation(URI.create("/auth/v1/logout"));
-        // 인증정보 갱신을 위한 로그아웃 uri로 리다이렉트
-        return new ResponseEntity<>(headers, HttpStatus.SEE_OTHER);
+        CreateIdentityResDto resDto = createIdentityService.execute(reqDto, manager.getId());
+        manager.setRole(resDto.userRole());
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "본인인증이 완료되었습니다"));
     }
 
     @GetMapping("/identity/me")

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -1,11 +1,14 @@
 package team.themoment.hellogsm.web.domain.identity.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.web.bind.annotation.*;
 
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
@@ -16,7 +19,6 @@ import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
 import team.themoment.hellogsm.web.domain.identity.service.ModifyIdentityService;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
-import java.net.URI;
 import java.util.Map;
 
 @RestController
@@ -40,10 +42,11 @@ public class IdentityController {
 
     @PostMapping("/identity/me")
     public ResponseEntity<Object> create(
+            HttpServletRequest httpServletRequest,
             @RequestBody @Valid IdentityReqDto reqDto
     ) {
         CreateIdentityResDto resDto = createIdentityService.execute(reqDto, manager.getId());
-        manager.setRole(resDto.userRole());
+        manager.setRole(httpServletRequest, resDto.userRole());
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("message", "본인인증이 완료되었습니다"));
     }
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import team.themoment.hellogsm.entity.domain.user.enums.Role;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
 import team.themoment.hellogsm.web.domain.identity.dto.response.CreateIdentityResDto;
@@ -55,14 +54,11 @@ public class IdentityController {
     }
 
     @PutMapping("/identity/me")
-    public ResponseEntity<IdentityDto> modify(
+    public ResponseEntity<Map<String, String>> modify(
             @RequestBody @Valid IdentityReqDto reqDto
     ) {
         modifyIdentityService.execute(reqDto, manager.getId());
-        HttpHeaders headers = new HttpHeaders();
-        headers.setLocation(URI.create("/auth/v1/logout"));
-        // 굳이 리다이렉트 할 필요는 없는데, create() 랑 리턴 타입을 맞추기 위해 리다이렉트
-        return new ResponseEntity<>(headers, HttpStatus.SEE_OTHER);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "수정되었습니다"));
     }
 
     @GetMapping("/identity/{userId}")

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityController.java
@@ -45,7 +45,7 @@ public class IdentityController {
     ) {
         CreateIdentityResDto resDto = createIdentityService.execute(reqDto, manager.getId());
         manager.setRole(resDto.userRole());
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "본인인증이 완료되었습니다"));
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("message", "본인인증이 완료되었습니다"));
     }
 
     @GetMapping("/identity/me")

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/response/CreateIdentityResDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/dto/response/CreateIdentityResDto.java
@@ -1,0 +1,19 @@
+package team.themoment.hellogsm.web.domain.identity.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import team.themoment.hellogsm.entity.domain.application.enums.Gender;
+import team.themoment.hellogsm.entity.domain.user.enums.Role;
+
+import java.time.LocalDate;
+
+public record CreateIdentityResDto(
+        Long id,
+        String name,
+        String phoneNumber,
+        @JsonFormat(pattern="yyyy-MM-dd")
+        LocalDate birth,
+        Gender gender,
+        Role userRole,
+        Long userId
+) {
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/mapper/IdentityMapper.java
@@ -5,8 +5,10 @@ import org.mapstruct.factory.Mappers;
 
 import team.themoment.hellogsm.entity.domain.application.enums.Gender;
 import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+import team.themoment.hellogsm.entity.domain.user.entity.User;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.dto.response.CreateIdentityResDto;
 
 @Mapper(
         componentModel = "spring",
@@ -26,6 +28,18 @@ public interface IdentityMapper {
             @Mapping(source = "userId", target = "userId")
     })
     IdentityDto identityToIdentityDto(Identity identity);
+
+    @BeanMapping(ignoreUnmappedSourceProperties = {"provider", "providerId"})
+    @Mappings({
+            @Mapping(source = "identity.id", target = "id"),
+            @Mapping(source = "identity.name", target = "name"),
+            @Mapping(source = "identity.phoneNumber", target = "phoneNumber"),
+            @Mapping(source = "identity.birth", target = "birth"),
+            @Mapping(source = "identity.gender", target = "gender"),
+            @Mapping(source = "user.role", target = "userRole"),
+            @Mapping(source = "identity.userId", target = "userId")
+    })
+    CreateIdentityResDto identityToCreateIdentityResDto(Identity identity, User user);
 
     // MapStruct 써서 구현하기 힘들어서 걍 함
     default Identity identityReqDtoToIdentity(IdentityReqDto identityReqDto, Long userId, Long identityId) {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CreateIdentityService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CreateIdentityService.java
@@ -1,7 +1,7 @@
 package team.themoment.hellogsm.web.domain.identity.service;
 
-import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.dto.response.CreateIdentityResDto;
 
 /**
  * identityReqDto와 userId를 받아 Identity를 생성하는 인터페이스입니다.
@@ -10,5 +10,5 @@ import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
  *  * @since 1.0.0
  */
 public interface CreateIdentityService {
-    IdentityDto execute(IdentityReqDto reqDto, Long userId);
+    CreateIdentityResDto execute(IdentityReqDto reqDto, Long userId);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
@@ -15,6 +15,7 @@ import team.themoment.hellogsm.entity.domain.user.enums.Role;
 import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.dto.response.CreateIdentityResDto;
 import team.themoment.hellogsm.web.domain.identity.mapper.IdentityMapper;
 import team.themoment.hellogsm.web.domain.identity.repository.CodeRepository;
 import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
@@ -48,7 +49,7 @@ public class CreateIdentityServiceImpl implements CreateIdentityService {
      * @throws ExpectedException 존재하지 않는 User나 이미 존재하는 Identity일 경우 발생
      */
     @Override
-    public IdentityDto execute(IdentityReqDto identityReqDto, Long userId) {
+    public CreateIdentityResDto execute(IdentityReqDto identityReqDto, Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("존재하지 않는 User 입니다", HttpStatus.BAD_REQUEST));
 
@@ -70,7 +71,7 @@ public class CreateIdentityServiceImpl implements CreateIdentityService {
         if (!recentCode.getPhoneNumber().equals(identityReqDto.phoneNumber()))
             throw new ExpectedException("유효하지 않은 요청입니다. code인증에 사용되었던 전화번호와 요청에 사용한 전화번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
 
-        userRepository.save(
+        User roleUpdatdeUser = userRepository.save(
                 new User(
                         user.getId(),
                         user.getProvider(),
@@ -83,6 +84,6 @@ public class CreateIdentityServiceImpl implements CreateIdentityService {
 
         codes.forEach(code -> codeRepository.deleteById(code.getCode())); // 인증이 성공한 경우 재사용 방지를 위해 해당 유저의 모든 code 제거
 
-        return IdentityMapper.INSTANCE.identityToIdentityDto(savedidentity);
+        return IdentityMapper.INSTANCE.identityToCreateIdentityResDto(savedidentity, roleUpdatdeUser);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -22,6 +22,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import team.themoment.hellogsm.web.global.security.handler.CustomUrlAuthenticationSuccessHandler;
 
 import java.util.Arrays;
 
@@ -109,7 +110,7 @@ public class SecurityConfig {
                 oauth2Login
                         .authorizationEndpoint().baseUri(oauth2LoginEndpointBaseUri).and()
                         .loginProcessingUrl(oauth2LoginProcessingUri)
-                        .successHandler(new SimpleUrlAuthenticationSuccessHandler(authEnv.redirectBaseUri()))
+                        .successHandler(new CustomUrlAuthenticationSuccessHandler(authEnv.redirectBaseUri()))
                         .failureHandler(new SimpleUrlAuthenticationFailureHandler(authEnv.redirectLoginFailureUri()))
 
         );

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -119,7 +119,7 @@ public class SecurityConfig {
     private void logout(HttpSecurity http) throws Exception {
         http.logout(logout -> logout
                 .logoutUrl(logoutUri)
-                .logoutSuccessUrl(authEnv.redirectBaseUri())
+                .logoutSuccessUrl(authEnv.redirectBaseUri()+"?logout=success")
         );
     }
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManager.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManager.java
@@ -8,4 +8,5 @@ public interface AuthenticatedUserManager {
     Long getId();
     Role getRole();
     LocalDateTime getLastLoginTime();
+    Role setRole(Role role);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManager.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManager.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.global.security.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
 
 import java.time.LocalDateTime;
@@ -8,5 +9,5 @@ public interface AuthenticatedUserManager {
     Long getId();
     Role getRole();
     LocalDateTime getLastLoginTime();
-    Role setRole(Role role);
+    Role setRole(HttpServletRequest req, Role role);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManagerImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManagerImpl.java
@@ -1,13 +1,17 @@
 package team.themoment.hellogsm.web.global.security.auth;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.stereotype.Component;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
+import team.themoment.hellogsm.web.global.security.oauth.UserInfo;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -34,7 +38,7 @@ public class AuthenticatedUserManagerImpl implements AuthenticatedUserManager {
     }
 
     @Override
-    public Role setRole(Role role) {
+    public Role setRole(HttpServletRequest req, Role role) {
         OAuth2AuthenticationToken oAuth2AuthenticationToken =
                 (OAuth2AuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
         OAuth2User oAuth2User = oAuth2AuthenticationToken.getPrincipal();
@@ -42,21 +46,22 @@ public class AuthenticatedUserManagerImpl implements AuthenticatedUserManager {
         Map<String, Object> newAttributes = new HashMap<>(oAuth2User.getAttributes());
         newAttributes.put("role", role.name());
 
-        OAuth2User newOAuth2User =
-                new DefaultOAuth2User(oAuth2User.getAuthorities(), newAttributes, "id");
-
         Collection<GrantedAuthority> newAuthorities = new ArrayList<>(oAuth2User.getAuthorities());
 
-        for (Role r : Role.values()) {
-            newAuthorities.remove(new SimpleGrantedAuthority(r.name()));
-        }
-
+        newAuthorities.remove(new SimpleGrantedAuthority(Role.ROLE_UNAUTHENTICATED.name()));
         newAuthorities.add(new SimpleGrantedAuthority(role.name()));
+
+        OAuth2User newOAuth2User =
+                new UserInfo(newAuthorities, newAttributes, "id");
 
         OAuth2AuthenticationToken newAuth = new OAuth2AuthenticationToken(
                 newOAuth2User, newAuthorities, oAuth2AuthenticationToken.getAuthorizedClientRegistrationId());
         SecurityContextHolder.getContext().setAuthentication(newAuth);
 
+        SecurityContext sc = SecurityContextHolder.getContext();
+        sc.setAuthentication(newAuth);
+        HttpSession session = req.getSession(true);
+        session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, sc);
         return role;
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManagerImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthenticatedUserManagerImpl.java
@@ -1,11 +1,16 @@
 package team.themoment.hellogsm.web.global.security.auth;
 
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
 
 import java.time.LocalDateTime;
+import java.util.*;
 
 @Component
 public class AuthenticatedUserManagerImpl implements AuthenticatedUserManager {
@@ -26,5 +31,32 @@ public class AuthenticatedUserManagerImpl implements AuthenticatedUserManager {
         OAuth2User oAuth2User =
                 (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         return oAuth2User.getAttribute("last_login_time");
+    }
+
+    @Override
+    public Role setRole(Role role) {
+        OAuth2AuthenticationToken oAuth2AuthenticationToken =
+                (OAuth2AuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+        OAuth2User oAuth2User = oAuth2AuthenticationToken.getPrincipal();
+
+        Map<String, Object> newAttributes = new HashMap<>(oAuth2User.getAttributes());
+        newAttributes.put("role", role.name());
+
+        OAuth2User newOAuth2User =
+                new DefaultOAuth2User(oAuth2User.getAuthorities(), newAttributes, "id");
+
+        Collection<GrantedAuthority> newAuthorities = new ArrayList<>(oAuth2User.getAuthorities());
+
+        for (Role r : Role.values()) {
+            newAuthorities.remove(new SimpleGrantedAuthority(r.name()));
+        }
+
+        newAuthorities.add(new SimpleGrantedAuthority(role.name()));
+
+        OAuth2AuthenticationToken newAuth = new OAuth2AuthenticationToken(
+                newOAuth2User, newAuthorities, oAuth2AuthenticationToken.getAuthorizedClientRegistrationId());
+        SecurityContextHolder.getContext().setAuthentication(newAuth);
+
+        return role;
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/handler/CustomUrlAuthenticationSuccessHandler.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/handler/CustomUrlAuthenticationSuccessHandler.java
@@ -1,0 +1,47 @@
+package team.themoment.hellogsm.web.global.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.WebAttributes;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.web.util.UriComponentsBuilder;
+import team.themoment.hellogsm.entity.domain.user.enums.Role;
+
+import java.io.IOException;
+
+public class CustomUrlAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final String defaultTargetUrl;
+
+    public CustomUrlAuthenticationSuccessHandler(String defaultTargetUrl) {
+        this.defaultTargetUrl = defaultTargetUrl;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        boolean isUnAuthentication = authentication.getAuthorities().stream()
+                .anyMatch(authority -> Role.ROLE_UNAUTHENTICATED.name().equals(authority.getAuthority()));
+
+        String redirectUrlWithParameter = UriComponentsBuilder
+                .fromUriString(defaultTargetUrl)
+                .queryParam("verification", !isUnAuthentication)
+                .build()
+                .toUriString();
+
+        response.sendRedirect(redirectUrlWithParameter);
+
+        clearAuthenticationAttributes(request);
+    }
+
+    protected final void clearAuthenticationAttributes(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.removeAttribute(WebAttributes.AUTHENTICATION_EXCEPTION);
+        }
+    }
+
+}

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/IdentityControllerTest.java
@@ -23,9 +23,11 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import team.themoment.hellogsm.entity.domain.application.enums.Gender;
+import team.themoment.hellogsm.entity.domain.user.enums.Role;
 import team.themoment.hellogsm.web.domain.common.ControllerTestUtil;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
+import team.themoment.hellogsm.web.domain.identity.dto.response.CreateIdentityResDto;
 import team.themoment.hellogsm.web.domain.identity.service.CreateIdentityService;
 import team.themoment.hellogsm.web.domain.identity.service.IdentityQuery;
 import team.themoment.hellogsm.web.domain.identity.service.ModifyIdentityService;
@@ -140,15 +142,25 @@ class IdentityControllerTest {
                 Gender.MALE.name(),
                 LocalDate.of(2007,01,01)
         );
-        Mockito.when(createIdentityService.execute(any(IdentityReqDto.class), any(Long.class))).thenReturn(identity);
+        CreateIdentityResDto response = new CreateIdentityResDto(
+                1L,
+                "홍길동",
+                "01012345678",
+                LocalDate.of(2007,01,01),
+                Gender.MALE,
+                Role.ROLE_USER,
+                userId
+        );
+        Mockito.when(createIdentityService.execute(any(IdentityReqDto.class), any(Long.class))).thenReturn(response);
         Mockito.when(manager.getId()).thenReturn(userId);
-        this.mockMvc.perform(post("/identity/v1/identity/me", userId, MediaType.APPLICATION_JSON)
+        this.mockMvc.perform(post("/identity/v1/identity/me", MediaType.APPLICATION_JSON)
                         .cookie(new Cookie("SESSION", "SESSIONID12345"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(this.objectMapper.writeValueAsString(request)))
-                .andExpect(status().isSeeOther())
+                .andExpect(status().isCreated())
                 .andDo(this.documentationHandler.document(
-                        requestSessionCookie()
+                        requestSessionCookie(),
+                        responseFields(fieldWithPath("message").type(STRING).description("작업 상태 설명"))
                 ));
     }
 
@@ -164,13 +176,14 @@ class IdentityControllerTest {
         );
         Mockito.when(modifyIdentityService.execute(any(IdentityReqDto.class), any(Long.class))).thenReturn(identity);
         Mockito.when(manager.getId()).thenReturn(userId);
-        this.mockMvc.perform(post("/identity/v1/identity/me", userId, MediaType.APPLICATION_JSON)
+        this.mockMvc.perform(put("/identity/v1/identity/me", MediaType.APPLICATION_JSON)
                         .cookie(new Cookie("SESSION", "SESSIONID12345"))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(this.objectMapper.writeValueAsString(request)))
-                .andExpect(status().isSeeOther())
+                .andExpect(status().isOk())
                 .andDo(this.documentationHandler.document(
-                        requestSessionCookie()
+                        requestSessionCookie(),
+                        responseFields(fieldWithPath("message").type(STRING).description("작업 상태 설명"))
                 ));
     }
 }


### PR DESCRIPTION
## 개요

본인인증, 로그인, 로그아웃 시 발생하는 리다이렉트 설정을 변경하였습니다.

## 본문

본인인증, 로그인, 로그아웃 시 발생하는 리다이렉트 설정을 변경하였습니다.
본인인증은 리다이렉트 대신 HttpStatus Ok를 반환하도록 대체되었습니다.
로그인, 로그아웃 시에는 상황에 따라서 Query String을 리턴하도록 변경하였습니다.

특정 Query String을 사용하게 된 이유는 다음과 같습니다.
- 메인 페이지로 리다이렉트 되는 경우가 여러가지입니다.
  - 로그인 
  - 로그아웃
  - 본인인증(현재는 아님)
- 해당 경우에 대한 상황을 사용자에게 알리기 위해서 다른 처리가 필요하였습니다.

#### [참고] 변경된 요구사항 정리
##### 본인인증
- FE에서 리다이렉트
- 본인인증 완료 →toast 메세지
- 본인인증 실패 → 계속 해당 페이지에서 머물기
##### 메인 url로 리다이렉트 시 상황 별로 Query String 지정
- Oauth(Login)
    - 인증 성공 시
        - verification = false : 인증되지 않은 사용자
        - verification = true : 인증된 사용자
    - 인증 실패 시
        - login = failure : 로그인 실패
- Logout
    - logout = success : 로그아웃 성공
ex) 인증된 유저가 로그인 한 후 리다이렉트되는 uri : `https://hellogsm.kr?verification=true`

### 추가 

- 현재 로그인한 사용자의 권한을 변경하는 AuthenticatedUserManager#setRole 기능 구현
- 본인인증 성공 시 사용되는 값을 담는 `CreateIdentityResDto` 구현
- `CustomUrlAuthenticationSuccessHandler` 구현 - 로그인 이후 사용자의 권한에 따라 다른 param 값을 가지고 리다이렉트
- `CreateIdentityResDto` mapper 구현

### 변경 

- `IdentityController#create` 이후 리다이렉트 동작 대신 HttpStatus Created 반환 + 리턴 타입을  `CreateIdentityResDto`로 변경
- `IdentityController#modify` 이후 리다이렉트 동작 대신 HttpStatus Ok 반환
- 로그인 성공 시 인증 여부에 따라서 `verification` 파라미터 값을 포함하여 리다이렉트
- 로그아웃 성공 시 `logout` 파라미터를 포함하여 리다이렉트
- 로직이 변경됨으로 인한 테스트코드 수정
