### PR TITLE
Domain 객체 Style 통일

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/Application.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/Application.java
@@ -61,7 +61,7 @@ public class Application {
      * @return 일관성 여부 (true: 일관성 만족, false: 일관성 불만족)
      */
     @AssertTrue(message = "admissionInfo의 graduationStatus와 AdmissionGrade의 형식이 일치하지 않습니다.")
-    private boolean hasConsistencyWithGraduationStatusAndAdmissionGrade() { // 이름;;
+    private boolean hasConsistency() {
         GraduationStatus graduationStatus = admissionInfo.getGraduation();
         boolean isGedGraduationStatus = graduationStatus.equals(GraduationStatus.GED);
         boolean isGraduateOrCandidateGraduationStatus = graduationStatus.equals(GraduationStatus.GRADUATE)

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
@@ -89,11 +89,6 @@ public class AdmissionInfo {
     @Embedded
     private DesiredMajor desiredMajor;
 
-    @AssertFalse(message = "DesiredMajor 가 null 임")
-    private boolean isDesiredMajorNull() {
-        return desiredMajor == null;
-    }
-
     public Optional<String> getTelephone() {
         return Optional.ofNullable(telephone);
     }
@@ -112,5 +107,10 @@ public class AdmissionInfo {
 
     public Optional<String> getTeacherPhoneNumber() {
         return Optional.ofNullable(teacherPhoneNumber);
+    }
+
+    @AssertFalse(message = "DesiredMajor 가 null 임")
+    private boolean isDesiredMajorNull() {
+        return desiredMajor == null;
     }
 }

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
@@ -38,40 +38,31 @@ public class AdmissionInfo {
     @Column(name = "applicant_name", nullable = false)
     private String applicantName;
 
-
     @Enumerated(EnumType.STRING)
     @Column(name = "applicant_gender", nullable = false)
     private Gender applicantGender;
 
-
     @Column(name = "applicant_birth", nullable = false)
     private LocalDate applicantBirth;
-
 
     @Column(name = "address", nullable = false)
     private String address;
 
-
     @Column(name = "detail_address", nullable = false)
     private String detailAddress;
-
 
     @Enumerated(EnumType.STRING)
     @Column(name = "graduation", nullable = false)
     private GraduationStatus graduation;
 
-
     @Column(name = "telephone", nullable = true)
     private String telephone;
-
 
     @Column(name = "applicant_phone_number", nullable = false)
     private String applicantPhoneNumber;
 
-
     @Column(name = "guardian_name", nullable = false)
     private String guardianName;
-
 
     @Column(name = "relation_with_applicant", nullable = false)
     private String relationWithApplicant;
@@ -123,4 +114,3 @@ public class AdmissionInfo {
         return Optional.ofNullable(teacherPhoneNumber);
     }
 }
-

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
@@ -96,7 +96,7 @@ public class AdmissionInfo {
     private String teacherPhoneNumber;
 
     @Embedded
-    DesiredMajor desiredMajor;
+    private DesiredMajor desiredMajor;
 
     @AssertFalse(message = "DesiredMajor 가 null 임")
     private boolean isDesiredMajorNull() {
@@ -122,6 +122,5 @@ public class AdmissionInfo {
     public Optional<String> getTeacherPhoneNumber() {
         return Optional.ofNullable(teacherPhoneNumber);
     }
-
 }
 

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/DesiredMajor.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/DesiredMajor.java
@@ -7,7 +7,6 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.AssertFalse;
 import lombok.*;
-import lombok.extern.slf4j.Slf4j;
 import team.themoment.hellogsm.entity.domain.application.enums.Major;
 
 import java.util.HashSet;
@@ -29,24 +28,18 @@ import java.util.Set;
 @ToString
 public class DesiredMajor {
 
-
     @Enumerated(EnumType.STRING)
     @Column(name = "first_desired_major", nullable = false)
     private Major firstDesiredMajor;
-
 
     @Enumerated(EnumType.STRING)
     @Column(name = "second_desired_major", nullable = false)
     private Major secondDesiredMajor;
 
-
     @Enumerated(EnumType.STRING)
     @Column(name = "third_desired_major", nullable = false)
     private Major thirdDesiredMajor;
 
-    // 조건보다 @AssertTrue가 먼저 실행되서 NullPointerException 이 발생할 수 있음
-    // 일단 null 여부를 확인하는 validation을 추가하긴 했는데, DTO에서 이미 확인하기 때문에 중복이라 좀 그럼
-    // @GroupSequence 사용해서 순서 정해주거나, 다른 방법 찾아보기
     @AssertFalse(message = "Null인 전공이 있습니다")
     private boolean hasNullMajor() {
         if (firstDesiredMajor == null || secondDesiredMajor == null || thirdDesiredMajor == null) {
@@ -57,10 +50,9 @@ public class DesiredMajor {
 
     @AssertFalse(message = "중복된 전공이 있습니다")
     private boolean hasSameMajor() {
-        if (hasNullMajor()) return false; // null이면 그냥 넘겨서 hasNullMajor()가 처리하게 유도
+        if (hasNullMajor()) return false; // NPE 방지를 위해서 사용, 어차피 false로 통과시켜도 다른 유효성 검사에서 catch 됨
         List<Major> majors = List.of(firstDesiredMajor, secondDesiredMajor, thirdDesiredMajor);
         Set<Major> deduplicationMajors = new HashSet<>(majors);
-        // 중복 체크를 위해 Set의 크기와 원본 리스트의 크기를 비교
         return deduplicationMajors.size() != majors.size();
     }
 }

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/DesiredMajor.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/DesiredMajor.java
@@ -24,10 +24,9 @@ import java.util.Set;
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 @Builder
 @ToString
-@Slf4j
-@Getter
 public class DesiredMajor {
 
 

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGrade.java
@@ -23,16 +23,14 @@ import java.math.BigDecimal;
 @ToString
 public abstract class AdmissionGrade {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "admission_grade_id", nullable = false)
     protected Long id;
 
-    
     @Column(name = "total_score", nullable = false)
     protected BigDecimal totalScore;
 
-    
     @Column(name = "percentile_rank", nullable = false)
     protected BigDecimal percentileRank;
-
 }

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGrade.java
@@ -13,12 +13,12 @@ import java.math.BigDecimal;
  * @since 1.0.0
  */
 @Entity
+@Table(name = "admission_grade")
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "admission_grade")
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @SuperBuilder
 @ToString
 public abstract class AdmissionGrade {
@@ -36,4 +36,3 @@ public abstract class AdmissionGrade {
     protected BigDecimal percentileRank;
 
 }
-

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GedAdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GedAdmissionGrade.java
@@ -32,6 +32,7 @@ import static lombok.AccessLevel.PROTECTED;
 @SuperBuilder
 @ToString
 public class GedAdmissionGrade extends AdmissionGrade {
+
     @Column(name = "ged_total_score", nullable = false)
     private BigDecimal gedTotalScore;
 

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GedAdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GedAdmissionGrade.java
@@ -25,10 +25,10 @@ import static lombok.AccessLevel.PROTECTED;
  * @since 1.0.0
  */
 @Entity
-@DiscriminatorValue("GED")
-@Getter
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PRIVATE)
+@DiscriminatorValue("GED")
+@Getter
 @SuperBuilder
 @ToString
 public class GedAdmissionGrade extends AdmissionGrade {

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GedAdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GedAdmissionGrade.java
@@ -35,7 +35,6 @@ public class GedAdmissionGrade extends AdmissionGrade {
     @Column(name = "ged_total_score", nullable = false)
     private BigDecimal gedTotalScore;
 
-
     @Column(name = "ged_max_score", nullable = false)
     private BigDecimal gedMaxScore;
 

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
@@ -21,10 +21,10 @@ import java.util.stream.Stream;
  * @since 1.0.0
  */
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @DiscriminatorValue("GRADUATE")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor//(access = AccessLevel.PRIVATE) 테스트용으로 주석
 @SuperBuilder
 @ToString
 public class GraduateAdmissionGrade extends AdmissionGrade {

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
@@ -29,42 +29,32 @@ import java.util.stream.Stream;
 @ToString
 public class GraduateAdmissionGrade extends AdmissionGrade {
 
-
     @Column(name = "grade_1_semester_1_score", nullable = false)
-    private BigDecimal grade1Semester1Score;  // 1 grade 1 semester 점수
-
+    private BigDecimal grade1Semester1Score;  // 1 grade(학년) 1 semester(학기) 점수
 
     @Column(name = "grade_1_semester_2_score", nullable = false)
     private BigDecimal grade1Semester2Score;
 
-
     @Column(name = "grade_2_semester_1_score", nullable = false)
     private BigDecimal grade2Semester1Score;
-
 
     @Column(name = "grade_2_semester_2_score", nullable = false)
     private BigDecimal grade2Semester2Score;
 
-
     @Column(name = "grade_3_semester_1_score", nullable = false)
     private BigDecimal grade3Semester1Score;
-
 
     @Column(name = "artistic_score", nullable = false)
     private BigDecimal artisticScore;
 
-
     @Column(name = "curricular_subtotal_score", nullable = false)
     private BigDecimal curricularSubtotalScore;
-
 
     @Column(name = "attendance_score", nullable = false)
     private BigDecimal attendanceScore;
 
-
     @Column(name = "volunteer_score", nullable = false)
     private BigDecimal volunteerScore;
-
 
     @Column(name = "extracurricular_subtotal_score", nullable = false)
     private BigDecimal extracurricularSubtotalScore;

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
@@ -25,6 +25,5 @@ public class MiddleSchoolGrade {
     @Lob
     @Column(name = "middle_school_grade_text", nullable = false)
     private String middleSchoolGradeText;
-
 }
 

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
@@ -10,9 +10,9 @@ import lombok.*;
  * @since 1.0.0
  */
 @Entity
+@Table(name = "middle_school_grade")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "middle_school_grade")
 @Getter
 @ToString
 public class MiddleSchoolGrade {

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/ScreeningCategory.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/ScreeningCategory.java
@@ -1,7 +1,7 @@
 package team.themoment.hellogsm.entity.domain.application.entity.grade;
 
 public enum ScreeningCategory {
-    GENERAL,
-    SOCIAL,
-    SPECIAL
+    GENERAL, // 일반전형
+    SOCIAL, // 특별전형(사회통합전형)
+    SPECIAL // 정원 외 특별전형
 }

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/data/GedScoreData.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/data/GedScoreData.java
@@ -2,7 +2,7 @@ package team.themoment.hellogsm.entity.domain.application.entity.grade.data;
 
 import java.math.BigDecimal;
 
-public record GedScoreData ( //TODO 유효성 검증 필요; 어느 레이어에서 할지는 미정임
+public record GedScoreData (
     BigDecimal curriculumScoreSubtotal,
     BigDecimal nonCurriculumScoreSubtotal,
     BigDecimal rankPercentage,

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/data/GeneralScoreData.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/data/GeneralScoreData.java
@@ -9,8 +9,7 @@ import java.util.List;
  * @author 변찬우
  * @since 1.0.0
  */
-public record GeneralScoreData( //TODO 유효성 검증 필요; 어느 레이어에서 할지는 미정임
-        // 국어, 도덕, 사회, 역사, 수학, 과학, 기가, 영어, ...
+public record GeneralScoreData(
         List<BigDecimal> score1_1,
         List<BigDecimal> score1_2,
         List<BigDecimal> score2_1,

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
@@ -61,6 +61,10 @@ public class AdmissionStatus {
     @Column(name = "second_score", nullable = true) // TODO 이름 바꾸기 - 2차 시험 점수
     private BigDecimal secondScore;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "final_major", nullable = true)
+    private Major finalMajor;
+
     public Optional<Screening> getScreeningSubmittedAt() {
         return Optional.ofNullable(screeningSubmittedAt);
     }
@@ -85,9 +89,13 @@ public class AdmissionStatus {
         return Optional.ofNullable(finalMajor);
     }
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "final_major", nullable = true)
-    private Major finalMajor; // "배정되지 않음" 상태를 표현하기 애패해서 일단은 null로 둠
+    public Boolean isFinalSubmitted() {
+        return isFinalSubmitted;
+    }
+
+    public Boolean isPrintsArrived() {
+        return isPrintsArrived;
+    }
 
     /**
      * 초기 상태의 {@code AdmissionStatus}를 생성합니다.
@@ -108,15 +116,6 @@ public class AdmissionStatus {
                 .build();
     }
 
-    public Boolean isFinalSubmitted() {
-        return isFinalSubmitted;
-    }
-
-    public Boolean isPrintsArrived() {
-        return isPrintsArrived;
-    }
-
-    // null이 아닌 기본 값이 있는 경우 기본값 정해주기
     @PrePersist
     public void prePersist() {
         isFinalSubmitted = isFinalSubmitted == null ? false : isFinalSubmitted;

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
@@ -19,9 +19,9 @@ import java.util.Optional;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 @Builder
 @ToString
-@Getter
 public class AdmissionStatus {
 
     @Id

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/enums/Screening.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/enums/Screening.java
@@ -3,8 +3,8 @@ package team.themoment.hellogsm.entity.domain.application.enums;
 import team.themoment.hellogsm.entity.domain.application.entity.grade.ScreeningCategory;
 
 public enum Screening {
-    GENERAL(ScreeningCategory.GENERAL),
-    SOCIAL(ScreeningCategory.SOCIAL),
+    GENERAL(ScreeningCategory.GENERAL), // 일반전형
+    SOCIAL(ScreeningCategory.SOCIAL), // 특별전형(사회통합전형)
     SPECIAL_VETERANS(ScreeningCategory.SPECIAL), // 국가보훈대상자
     SPECIAL_ADMISSION(ScreeningCategory.SPECIAL); // 특례입학대상자
 
@@ -14,7 +14,6 @@ public enum Screening {
         this.category = category;
     }
 
-    // Getter 메소드 (선택 사항)
     public ScreeningCategory getCategory() {
         return category;
     }

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/user/entity/User.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/user/entity/User.java
@@ -11,6 +11,7 @@ import team.themoment.hellogsm.entity.domain.user.enums.Role;
 @Getter
 @ToString
 public class User {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -30,5 +31,4 @@ public class User {
     private void prePersist() {
         this.role = this.role == null ? Role.ROLE_UNAUTHENTICATED : this.role;
     }
-
 }

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/user/entity/User.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/user/entity/User.java
@@ -1,10 +1,7 @@
 package team.themoment.hellogsm.entity.domain.user.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
 
 @Entity
@@ -12,6 +9,7 @@ import team.themoment.hellogsm.entity.domain.user.enums.Role;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@ToString
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 개요

Domain 객체의 Style(들여쓰기, Annotation 순서)를 통일하고, 필요없는 주석을 제거하였습니다.

## 본문

### 클래스 어노테이션 우선순위
1. 클래스 관련 
2. 생성자 관련
3. 상속 관련
4. Getter, Setter, Builder
5. 그 외 유틸성 어노테이션

### 변경 

- Style 통일을 위해 대다수의 도메인 객체가 변경되었습니다.
- 일부 주석을 삭제하거나 수정, 추가하였습니다.
