### PR TITLE
entity(common) 모듈 의존성 설정 변경

### DIFF
--- a/hellogsm-entity/build.gradle
+++ b/hellogsm-entity/build.gradle
@@ -2,9 +2,9 @@ bootJar { enabled = false }
 jar { enabled = true }
 
 dependencies {
-	implementation 'jakarta.persistence:jakarta.persistence-api'
-	implementation 'org.springframework.boot:spring-boot-starter-validation' // @NotNull도 대체 가능하고, @AsserTrue도 대체 가능한데 일단 모듈 분리하는게 우선순위라 코드 수정 줄이기 위해 추가
-	implementation 'com.fasterxml.jackson.core:jackson-databind' //TODO 어플리케이션 Grade 리팩토링 할 때 지울 예정
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation' // TODO 나중에 여유 될 때 의존성 지우기
+	implementation 'com.fasterxml.jackson.core:jackson-databind' // 2024년에 원서 성적 관련 부분 로직 개편하면서 의존성 지우기
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 개요

JPA 의존성을 가지도록 변경하였습니다.

## 본문

DomainEvent 기능을 사용하기 위해 `spring-boot-starter-data-jpa` 의존성을 가지도록 변경하였습니다.

### 변경

- `spring-boot-starter-data-jpa` 의존성을 가지도록 변경


### 기타

현재 entity라는 이름을 사용하고 있지만, common 로 이름을 변경하면서 역할도 그에 맞게 수정될 계획입니다.
