### PR TITLE
Application, Identity간의 일관성 유지 로직을 Event 방식으로 리팩토링

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/identity/entity/Identity.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/identity/entity/Identity.java
@@ -4,7 +4,9 @@ import java.time.LocalDate;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.domain.AbstractAggregateRoot;
 import team.themoment.hellogsm.entity.domain.application.enums.Gender;
+import team.themoment.hellogsm.entity.domain.identity.event.UpdateIdentityEvent;
 
 /**
  * 본인인증 정보를 저장하는 Identity Entity입니다.
@@ -15,10 +17,9 @@ import team.themoment.hellogsm.entity.domain.application.enums.Gender;
 @Entity
 @Table(name = "identity")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 @ToString
-public class Identity {
+public class Identity extends AbstractAggregateRoot<Identity> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,4 +41,18 @@ public class Identity {
 
     @Column(name = "user_id", unique = true)
     private Long userId;
+
+    public Identity(Long id, String name, String phoneNumber, LocalDate birth, Gender gender, Long userId) {
+        this.id = id;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.birth = birth;
+        this.gender = gender;
+        this.userId = userId;
+        this.publishEvent();
+    }
+
+    public void publishEvent() {
+        this.registerEvent(new UpdateIdentityEvent(this));
+    }
 }

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/identity/event/UpdateIdentityEvent.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/identity/event/UpdateIdentityEvent.java
@@ -1,0 +1,5 @@
+package team.themoment.hellogsm.entity.domain.identity.event;
+
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+
+public record UpdateIdentityEvent(Identity identity) {}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -1,9 +1,9 @@
 package team.themoment.hellogsm.web.domain.application.mapper;
 
+import io.micrometer.common.lang.Nullable;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
-
-import io.micrometer.common.lang.Nullable;
+import team.themoment.hellogsm.entity.common.util.OptionalUtils;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
 import team.themoment.hellogsm.entity.domain.application.entity.admission.AdmissionInfo;
 import team.themoment.hellogsm.entity.domain.application.entity.admission.DesiredMajor;
@@ -15,17 +15,13 @@ import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
 import team.themoment.hellogsm.entity.domain.application.enums.Major;
 import team.themoment.hellogsm.entity.domain.application.enums.Screening;
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
 import team.themoment.hellogsm.web.domain.application.dto.domain.*;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationStatusReqDto;
-import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
-import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListInfoDto;
-import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationsDto;
-import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplicationRes;
-import team.themoment.hellogsm.web.domain.application.dto.response.TicketResDto;
+import team.themoment.hellogsm.web.domain.application.dto.response.*;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
-import team.themoment.hellogsm.entity.common.util.OptionalUtils;
 
 import java.util.List;
 
@@ -177,16 +173,16 @@ public interface ApplicationMapper {
         Screening screeningSecondEvaluationAt = null;
 
         try {
-            if(applicationStatusReqDto.finalMajor() != null)
+            if (applicationStatusReqDto.finalMajor() != null)
                 finalMajor = Major.valueOf(applicationStatusReqDto.finalMajor());
-            if(applicationStatusReqDto.screeningSubmittedAt() != null)
+            if (applicationStatusReqDto.screeningSubmittedAt() != null)
                 screeningSubmittedAt = Screening.valueOf(applicationStatusReqDto.screeningSubmittedAt());
-            if(applicationStatusReqDto.screeningFirstEvaluationAt() != null)
+            if (applicationStatusReqDto.screeningFirstEvaluationAt() != null)
                 screeningFirstEvaluationAt = Screening.valueOf(applicationStatusReqDto.screeningFirstEvaluationAt());
-            if(applicationStatusReqDto.screeningSecondEvaluationAt() != null)
+            if (applicationStatusReqDto.screeningSecondEvaluationAt() != null)
                 screeningSecondEvaluationAt = Screening.valueOf(applicationStatusReqDto.screeningSecondEvaluationAt());
         } catch (Exception ex) {
-            throw new RuntimeException("예상하지 못한 에러 발생",ex);
+            throw new RuntimeException("예상하지 못한 에러 발생", ex);
         }
 
         return AdmissionStatus.builder()
@@ -265,22 +261,22 @@ public interface ApplicationMapper {
     }
 
     @BeanMapping(ignoreUnmappedSourceProperties = {
+            "userId",
             "applicantName",
             "applicantGender",
             "applicantBirth",
-            "applicantPhoneNumber",
-            "code"
+            "applicantPhoneNumber"
     })
     @Mappings({
             @Mapping(source = "admissionInfo.id", target = "id"),
             @Mapping(source = "admissionInfo.applicantImageUri", target = "applicantImageUri"),
-            @Mapping(source = "identityReqDto.name", target = "applicantName"),
-            @Mapping(source = "identityReqDto.gender", target = "applicantGender"),
-            @Mapping(source = "identityReqDto.birth", target = "applicantBirth"),
+            @Mapping(source = "identity.name", target = "applicantName"),
+            @Mapping(source = "identity.gender", target = "applicantGender"),
+            @Mapping(source = "identity.birth", target = "applicantBirth"),
             @Mapping(source = "admissionInfo.address", target = "address"),
             @Mapping(source = "admissionInfo.detailAddress", target = "detailAddress"),
             @Mapping(source = "admissionInfo.telephone", target = "telephone"),
-            @Mapping(source = "identityReqDto.phoneNumber", target = "applicantPhoneNumber"),
+            @Mapping(source = "identity.phoneNumber", target = "applicantPhoneNumber"),
             @Mapping(source = "admissionInfo.guardianName", target = "guardianName"),
             @Mapping(source = "admissionInfo.relationWithApplicant", target = "relationWithApplicant"),
             @Mapping(source = "admissionInfo.guardianPhoneNumber", target = "guardianPhoneNumber"),
@@ -293,5 +289,5 @@ public interface ApplicationMapper {
             @Mapping(source = "admissionInfo.desiredMajor.secondDesiredMajor", target = "desiredMajor.secondDesiredMajor"),
             @Mapping(source = "admissionInfo.desiredMajor.thirdDesiredMajor", target = "desiredMajor.thirdDesiredMajor"),
     })
-    AdmissionInfo toConsistentAdmissionInfoWithIdentity(AdmissionInfo admissionInfo, IdentityReqDto identityReqDto);
+    AdmissionInfo toConsistentAdmissionInfoWithIdentity(AdmissionInfo admissionInfo, Identity identity);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ModifyApplicationForConsistency.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ModifyApplicationForConsistency.java
@@ -1,0 +1,7 @@
+package team.themoment.hellogsm.web.domain.application.service;
+
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+
+public interface ModifyApplicationForConsistency {
+    void execute(Identity identity);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationForConsistencyImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationForConsistencyImpl.java
@@ -1,0 +1,38 @@
+package team.themoment.hellogsm.web.domain.application.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsm.entity.domain.application.entity.Application;
+import team.themoment.hellogsm.entity.domain.application.entity.admission.AdmissionInfo;
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+import team.themoment.hellogsm.web.domain.application.mapper.ApplicationMapper;
+import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
+import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationForConsistency;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ModifyApplicationForConsistencyImpl implements ModifyApplicationForConsistency {
+    private final ApplicationRepository applicationRepository;
+
+    @Override
+    public void execute(Identity identity) {
+        Optional<Application> savedApplicationOpt = applicationRepository.findByUserId(identity.getUserId());
+
+        if (savedApplicationOpt.isPresent()) {
+            Application savedApplication = savedApplicationOpt.get();
+            AdmissionInfo newAdmissionInfo =
+                    ApplicationMapper.INSTANCE.toConsistentAdmissionInfoWithIdentity(savedApplication.getAdmissionInfo(), identity);
+
+            applicationRepository.save(
+                    new Application(
+                            savedApplication.getId(),
+                            newAdmissionInfo,
+                            savedApplication.getAdmissionStatus(),
+                            savedApplication.getMiddleSchoolGrade(),
+                            savedApplication.getUserId()
+                    ));
+        }
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/event/UpdateIdentityEventHandler.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/event/UpdateIdentityEventHandler.java
@@ -1,0 +1,18 @@
+package team.themoment.hellogsm.web.domain.identity.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import team.themoment.hellogsm.entity.domain.identity.event.UpdateIdentityEvent;
+import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationForConsistency;
+
+@Component
+@RequiredArgsConstructor
+public class UpdateIdentityEventHandler {
+    private final ModifyApplicationForConsistency modifyApplicationForConsistency;
+
+    @EventListener
+    public void updateIdentityEventHandler(UpdateIdentityEvent event) {
+        modifyApplicationForConsistency.execute(event.identity());
+    }
+}


### PR DESCRIPTION
## 개요

Application, Identity간의 일관성 유지 로직을 Event 방식으로 리팩토링하여 결합도를 낮추었습니다.

## 본문

기존에 Identity가 수정되는 경우, Application의 일부 필드도 함께 수정하기 때문에 서로 도메인을 의존하게 되는 문제가 있었습니다.
해당 문제를 해결하기 위해 Identity가 수정되는 경우 Event를 발급하여 Application단에서 Event를 받아 처리하도록 변경하였습니다.

### 추가 
- `ModifyApplicationForConsistency` 서비스 객체 & 해당 서비스 구현체 구현
- `UpdateIdentityEvent` 및 `UpdateIdentityEventHandler` 구현


### 변경 
- `ApplicationMapper#toConsistentAdmissionInfoWithIdentity` 구현 변경
- 기존 `ModifyIdentityService#execute`의 Application 수정 로직 삭제
- `Identity` 객체가 `AbstractAggregateRoot`를 상속받도록 변경

