### PR TITLE
수험표 생성 로직 변경

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -97,13 +97,8 @@ public class ApplicationController {
     }
 
     @GetMapping("/tickets")
-    public List<TicketResDto> tickets(
-            @RequestParam("page") Integer page,
-            @RequestParam("size") Integer size
-    ) {
-        if (page < 0 || size < 0)
-            throw new ExpectedException("0 이상만 가능합니다", HttpStatus.BAD_REQUEST);
-        return queryTicketsService.execute(page, size);
+    public ResponseEntity<List<TicketResDto>> tickets() {
+        return ResponseEntity.status(HttpStatus.OK).body(queryTicketsService.execute());
     }
 
     @PostMapping("/image")

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/TicketResDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/TicketResDto.java
@@ -2,15 +2,14 @@ package team.themoment.hellogsm.web.domain.application.dto.response;
 
 import team.themoment.hellogsm.entity.domain.application.enums.Gender;
 import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
+import team.themoment.hellogsm.entity.domain.application.enums.Screening;
 
 public record TicketResDto(
-        Long applicationId,
         String applicantName,
-        Gender applicantGender,
         String applicantBirth,
         String applicantImageUri,
-        String address,
-        GraduationStatus graduation,
+        String schoolName,
+        Screening screening,
         Long registrationNumber
 ) {
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -123,20 +123,18 @@ public interface ApplicationMapper {
     })
     AdmissionStatusDto admissionStatusToAdmissionStatusDto(AdmissionStatus admissionStatus);
 
-    @BeanMapping(ignoreUnmappedSourceProperties = {"middleSchoolGrade", "admissionGrade", "userId"})
+    @BeanMapping(ignoreUnmappedSourceProperties = {"id", "middleSchoolGrade", "admissionGrade", "userId"})
     @Mappings({
-            @Mapping(source = "id", target = "applicationId"),
             @Mapping(source = "admissionInfo.applicantName", target = "applicantName"),
-            @Mapping(source = "admissionInfo.applicantGender", target = "applicantGender"),
             @Mapping(source = "admissionInfo.applicantBirth", target = "applicantBirth"),
             @Mapping(source = "admissionInfo.applicantImageUri", target = "applicantImageUri"),
-            @Mapping(source = "admissionInfo.address", target = "address"),
-            @Mapping(source = "admissionInfo.graduation", target = "graduation"),
+            @Mapping(source = "admissionInfo.schoolName", target = "schoolName"),
+            @Mapping(source = "admissionInfo.screening", target = "screening"),
             @Mapping(source = "admissionStatus.registrationNumber", target = "registrationNumber"),
     })
     TicketResDto ApplicationToTicketResDto(Application application);
 
-    List<TicketResDto> ApplicationListToTicketResDtoList(List<Application> applicationList);
+    List<TicketResDto> ApplicationListToTicketResDtoList(List<Application> applicationList); // TODO 이름 ~s로 교체
 
     default ApplicationListDto createApplicationListDto(List<Application> applicationList) {
         return new ApplicationListDto(

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -21,7 +21,6 @@ import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReq
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationStatusReqDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.*;
 import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
-import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
 
 import java.util.List;
 
@@ -134,7 +133,7 @@ public interface ApplicationMapper {
     })
     TicketResDto ApplicationToTicketResDto(Application application);
 
-    List<TicketResDto> ApplicationListToTicketResDtoList(List<Application> applicationList); // TODO 이름 ~s로 교체
+    List<TicketResDto> ApplicationListToTicketResDtos(List<Application> applicationList);
 
     default ApplicationListDto createApplicationListDto(List<Application> applicationList) {
         return new ApplicationListDto(

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
@@ -27,5 +27,5 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
 
     void deleteApplicationByUserId(Long userId);
 
-    Page<Application> findAllByAdmissionStatus_FirstEvaluation(EvaluationStatus evaluationStatus, Pageable pageable);
+    List<Application> findAllByAdmissionStatus_FirstEvaluation(EvaluationStatus evaluationStatus);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/QueryTicketsService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/QueryTicketsService.java
@@ -5,5 +5,5 @@ import team.themoment.hellogsm.web.domain.application.dto.response.TicketResDto;
 import java.util.List;
 
 public interface QueryTicketsService {
-    List<TicketResDto> execute(Integer page, Integer size);
+    List<TicketResDto> execute();
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/QueryTicketsServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/QueryTicketsServiceImpl.java
@@ -21,11 +21,10 @@ public class QueryTicketsServiceImpl implements QueryTicketsService {
     final private ApplicationRepository applicationRepository;
 
     @Override
-    public List<TicketResDto> execute(Integer page, Integer size) {
-        Pageable pageable =  PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
-        Page<Application> applicationList =
-                applicationRepository.findAllByAdmissionStatus_FirstEvaluation(EvaluationStatus.PASS, pageable);
+    public List<TicketResDto> execute() {
+        List<Application> applicationList =
+                applicationRepository.findAllByAdmissionStatus_FirstEvaluation(EvaluationStatus.PASS);
 
-        return ApplicationMapper.INSTANCE.ApplicationListToTicketResDtoList(applicationList.getContent());
+        return ApplicationMapper.INSTANCE.ApplicationListToTicketResDtoList(applicationList);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/QueryTicketsServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/QueryTicketsServiceImpl.java
@@ -1,10 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
 import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
@@ -25,6 +21,6 @@ public class QueryTicketsServiceImpl implements QueryTicketsService {
         List<Application> applicationList =
                 applicationRepository.findAllByAdmissionStatus_FirstEvaluation(EvaluationStatus.PASS);
 
-        return ApplicationMapper.INSTANCE.ApplicationListToTicketResDtoList(applicationList);
+        return ApplicationMapper.INSTANCE.ApplicationListToTicketResDtos(applicationList);
     }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -616,18 +616,16 @@ class ApplicationControllerTest {
     void tickets() throws Exception {
         List<TicketResDto> ticketResDto = List.of(
                 new TicketResDto(
-                        1L,
                         "누군가",
-                        Gender.MALE,
                         "20030423",
                         "https://naver.com",
                         "이세상 어딘가",
-                        GraduationStatus.GRADUATE,
-                        1L
+                        Screening.GENERAL,
+                        1002L
                 )
         );
 
-        Mockito.when(queryTicketsService.execute(any(Integer.class), any(Integer.class))).thenReturn(ticketResDto);
+        Mockito.when(queryTicketsService.execute()).thenReturn(ticketResDto);
 
         this.mockMvc.perform(get("/application/v1/tickets")
                         .param("page", "0")
@@ -636,13 +634,11 @@ class ApplicationControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$[0].applicationId").value(ticketResDto.get(0).applicationId()))
                 .andExpect(jsonPath("$[0].applicantName").value(ticketResDto.get(0).applicantName()))
-                .andExpect(jsonPath("$[0].applicantGender").value(ticketResDto.get(0).applicantGender().toString()))
                 .andExpect(jsonPath("$[0].applicantBirth").value(ticketResDto.get(0).applicantBirth()))
                 .andExpect(jsonPath("$[0].applicantImageUri").value(ticketResDto.get(0).applicantImageUri()))
-                .andExpect(jsonPath("$[0].address").value(ticketResDto.get(0).address()))
-                .andExpect(jsonPath("$[0].graduation").value(ticketResDto.get(0).graduation().toString()))
+                .andExpect(jsonPath("$[0].screening").value(ticketResDto.get(0).screening().toString()))
+                .andExpect(jsonPath("$[0].schoolName").value(ticketResDto.get(0).schoolName()))
                 .andExpect(jsonPath("$[0].registrationNumber").value(ticketResDto.get(0).registrationNumber()))
                 .andDo(this.documentationHandler.document(
                         queryParameters(
@@ -650,13 +646,11 @@ class ApplicationControllerTest {
                                 parameterWithName("size").description("원서 크기")
                         ),
                         responseFields(
-                                fieldWithPath("[].applicationId").type(NUMBER).description("원서 식별자"),
                                 fieldWithPath("[].applicantName").type(STRING).description("지원자 이름"),
-                                fieldWithPath("[].applicantGender").type(STRING).description("지원자 성별"),
                                 fieldWithPath("[].applicantBirth").type(STRING).description("지원자 생년월일"),
-                                fieldWithPath("[].applicantImageUri").type(STRING).description("지원자 증명사진"),
-                                fieldWithPath("[].address").type(STRING).description("지원자 주소"),
-                                fieldWithPath("[].graduation").type(STRING).description("지원자 졸업 상태"),
+                                fieldWithPath("[].applicantImageUri").type(STRING).description("지원자 증명사진 URL"),
+                                fieldWithPath("[].schoolName").type(STRING).description("지원자 학교 이름"),
+                                fieldWithPath("[].screening").type(STRING).description("지원자 지원 전형"),
                                 fieldWithPath("[].registrationNumber").type(NUMBER).description("접수 번호")
                         )
                 ));


### PR DESCRIPTION
## 개요

요구사항과 다르게 구현되어 있는 수험표 생성 로직을 알맞게 수정하였습니다.

## 본문

- 요구사항에 알맞게 리턴 값을 변경하였습니다.
- paging 기능을 삭제하고, 리턴 타입을 타 api와 동일하게 `ResponseEntity` 로 변경하였습니다.
