### PR TITLE
원서 id로 조회 로직 버그 수정

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
@@ -20,7 +20,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     Optional<Application> findByUserId(Long userId);
     Boolean existsByUserId(Long userId);
 
-    @Query("select a from Application a join fetch a.admissionGrade join fetch a.admissionInfo join fetch a.admissionStatus join fetch a.middleSchoolGrade")
+    @Query("select a from Application a join fetch a.admissionGrade join fetch a.admissionInfo join fetch a.admissionStatus join fetch a.middleSchoolGrade where a.userId = :userId")
     Optional<Application> findByUserIdEagerFetch(Long userId);
 
     Page<Application> findAll(Pageable pageable);


### PR DESCRIPTION
## 개요

원서 id를 사용한 단일 조회 시, 여러 데이터가 불러와지는 문제를 해결하였습니다.

## 본문

id를 사용한 조건걸이 누락되어, 모든 원서를 불러와 에러가 발생하였습니다.
누락된 조건절을 추가하여 해결하였습니다.

