### PR TITLE
테스트용 본인인증 코드 생성 서비스 수정

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/CodeController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/controller/CodeController.java
@@ -15,6 +15,7 @@ import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeR
 import team.themoment.hellogsm.web.domain.identity.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsm.web.domain.identity.service.AuthenticateCodeService;
 import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
+import team.themoment.hellogsm.web.domain.identity.service.GenerateTestCodeService;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 @RestController
@@ -23,6 +24,7 @@ import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager
 public class CodeController {
     private final AuthenticatedUserManager manager;
     private final GenerateCodeService generateCodeService;
+    private final GenerateTestCodeService generateTestCodeService;
     private final AuthenticateCodeService authenticateCodeService;
 
     @PostMapping("/identity/me/send-code")
@@ -37,7 +39,7 @@ public class CodeController {
     public ResponseEntity<Map> sendCodeTest(
             @RequestBody @Valid GenerateCodeReqDto reqDto
     ) {
-        var code = generateCodeService.execute(manager.getId(), reqDto);
+        var code = generateTestCodeService.execute(manager.getId(), reqDto);
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "전송되었습니다. : " + code));
     }
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/GenerateTestCodeService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/GenerateTestCodeService.java
@@ -1,0 +1,8 @@
+package team.themoment.hellogsm.web.domain.identity.service;
+
+import team.themoment.hellogsm.web.domain.identity.dto.request.GenerateCodeReqDto;
+
+// TODO 나중에 기능 합치던가 하기
+public interface GenerateTestCodeService {
+    String execute(Long userId, GenerateCodeReqDto reqDto);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/GenerateTestCodeServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/GenerateTestCodeServiceImpl.java
@@ -1,0 +1,45 @@
+package team.themoment.hellogsm.web.domain.identity.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
+import team.themoment.hellogsm.web.domain.identity.dto.request.GenerateCodeReqDto;
+import team.themoment.hellogsm.web.domain.identity.repository.CodeRepository;
+import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
+import team.themoment.hellogsm.web.domain.identity.service.GenerateTestCodeService;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class GenerateTestCodeServiceImpl implements GenerateTestCodeService {
+    private final static Random RANDOM = new Random();
+    public final static int DIGIT_NUMBER = GenerateCodeServiceImpl.DIGIT_NUMBER;
+    public final static int MAX = GenerateCodeServiceImpl.MAX;
+
+    private final CodeRepository codeRepository;
+
+    @Override
+    public String execute(Long userId, GenerateCodeReqDto reqDto) {
+        final String code = generateUniqueCode();
+        codeRepository.save(new AuthenticationCode(code, userId, false, reqDto.phoneNumber(), LocalDateTime.now()));
+        return code;
+    }
+
+    private String generateUniqueCode() {
+        String code;
+        do {
+            code = getRandomCode();
+        } while (isDuplicate(code));
+        return code;
+    }
+
+    private Boolean isDuplicate(String code) {
+        return codeRepository.findById(code).isPresent();
+    }
+
+    public static String getRandomCode() {
+        return String.format("%0" + DIGIT_NUMBER + "d", RANDOM.nextInt(0, MAX + 1));
+    }
+}

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/CodeControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/identity/controller/CodeControllerTest.java
@@ -38,6 +38,7 @@ import team.themoment.hellogsm.web.domain.identity.dto.request.AuthenticateCodeR
 import team.themoment.hellogsm.web.domain.identity.dto.request.GenerateCodeReqDto;
 import team.themoment.hellogsm.web.domain.identity.service.AuthenticateCodeService;
 import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
+import team.themoment.hellogsm.web.domain.identity.service.GenerateTestCodeService;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 @Tag("restDocsTest")
@@ -54,6 +55,8 @@ class CodeControllerTest {
     private AuthenticatedUserManager manager;
     @MockBean
     private GenerateCodeService generateCodeService;
+    @MockBean
+    private GenerateTestCodeService generateTestCodeService;
     @MockBean
     private AuthenticateCodeService authenticateCodeService;
 
@@ -91,7 +94,7 @@ class CodeControllerTest {
         Long userId = 1L;
         GenerateCodeReqDto request = new GenerateCodeReqDto("0101234678");
         String generatedCode = "123456";
-        Mockito.when(generateCodeService.execute(any(Long.class), any(GenerateCodeReqDto.class))).thenReturn(generatedCode);
+        Mockito.when(generateTestCodeService.execute(any(Long.class), any(GenerateCodeReqDto.class))).thenReturn(generatedCode);
         Mockito.when(manager.getId()).thenReturn(userId);
 
         this.mockMvc.perform(post("/identity/v1/identity/me/send-code-test", userId, MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 개요

테스트 용 본인인증코드 생성 서비스를 추가하였습니다. 
## 본문

새로 구현한 테스트 용 본인인증 코드 서비스 `GenerateTestCodeService`는 AWS SMS를 호출하지 않으며, 코드 생성 횟수 제한을 가지고 있지 않습니다.
테스트 시 비용이 발생하지 않고, 비용이 소모되지 않도록 변경하였습니다.
