### PR TITLE
middleSchoolGradeText 필드 길이제한 증가

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
@@ -23,7 +23,7 @@ public class MiddleSchoolGrade {
     private Long id;
 
     @Lob
-    @Column(name = "middle_school_grade_text", nullable = false)
+    @Column(name = "middle_school_grade_text", nullable = false, length = 10000)
     private String middleSchoolGradeText;
 }
 


### PR DESCRIPTION
## 개요

middleSchoolGradeText 필드가 defalut 값인 255 바이트로 설정되어 실제 데이터 입력 시 `Data too long for column` 예외가 발생하였습니다.
middleSchoolGradeText 필드의 길이제한을 10000으로 설정하여 에러가 발생하지 않도록 수정하였습니다.
