### PR TITLE
ApplicationMapper 잘못된 필드 사용 문제 해결

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -249,7 +249,7 @@ public interface ApplicationMapper {
         MiddleSchoolGrade middleSchoolGrade = new MiddleSchoolGrade(userId, applicationReqDto.middleSchoolGrade());
 
         return new Application(
-                userId,
+                appId,
                 admissionInfo,
                 admissionStatus,
                 middleSchoolGrade,


### PR DESCRIPTION
## 개요

`ApplicationMapper#applicationReqDtoAndIdentityDtoToApplication` 에서 applicationId가 들어가야 할 자리에 userId가 들어가 있는 문제를 해결하였습니다.
