### PR TITLE
Application 하위 엔티티 @GeneratedValue 어노테이션 제거

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 public class AdmissionInfo {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "admission_info_id")
     private Long id;
 

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
@@ -18,7 +18,6 @@ import lombok.*;
 public class MiddleSchoolGrade {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "middle_school_grade_id", nullable = false)
     private Long id;
 

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 public class AdmissionStatus {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "application_status_id")
     private Long id;
 


### PR DESCRIPTION
## 개요

Application 하위 엔티티에 `@GeneratedValue` 어노테이션 제거

## 본문

Application 하위 엔티티들은 생성 시점에 userId를 id로 할당해주기 때문에 `@GeneratedValue`를 사용하면 원서 생성 시
`InvalidDataAccessApiUsageException` 에러가 발생합니다.

`@GeneratedValue` 어노테이션 제거하여 문제를 해결하였습니다.
