### PR TITLE
유저 탈퇴기능 추가

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/user/event/DeleteUserEvent.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/user/event/DeleteUserEvent.java
@@ -1,0 +1,6 @@
+package team.themoment.hellogsm.entity.domain.user.event;
+
+import team.themoment.hellogsm.entity.domain.user.entity.User;
+
+public record DeleteUserEvent(User user) {
+}

--- a/hellogsm-web/src/docs/asciidoc/index.adoc
+++ b/hellogsm-web/src/docs/asciidoc/index.adoc
@@ -200,6 +200,22 @@ operation::user/find-by-authenticated[snippets='curl-request,http-request']
 ==== Response
 operation::user/find-by-authenticated[snippets='http-response,response-fields']
 
+=== [DELETE] user/me
+현재 사용자 정보를 삭제하는 엔드포인트입니다.
+
+관련된 본인인증과 원서 데이터 또한 삭제됩니다.
+
+WARNING: 단, 최종제출 된(실물 서류 접수 여부과 무관하게) 원서는 삭제되지 않습니다.
+
+==== 사용 가능한 권한
+    ROLE_UNAUTHENTICATED, ROLE_USER
+
+==== Request
+operation::user/delete-by-authenticated[snippets='curl-request,http-request']
+
+==== Response
+operation::user/delete-by-authenticated[snippets='http-response,response-fields']
+
 == identity/v1/
 *신원(Identity)*
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/CascadeDeleteApplicationService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/CascadeDeleteApplicationService.java
@@ -1,0 +1,7 @@
+package team.themoment.hellogsm.web.domain.application.service;
+
+import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
+
+public interface CascadeDeleteApplicationService {
+    void execute(Long userId);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CascadeDeleteApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CascadeDeleteApplicationServiceImpl.java
@@ -22,7 +22,12 @@ public class CascadeDeleteApplicationServiceImpl implements CascadeDeleteApplica
         final Optional<Application> optionalApplication = applicationRepository.findByUserId(userId);
 
         if (optionalApplication.isPresent()) {
-            applicationRepository.deleteById(optionalApplication.get().getId());
+            Application application = optionalApplication.get();
+            if (application.getAdmissionStatus().getIsFinalSubmitted()) {
+                log.warn("최종제출 된 Application 삭제 요청 발생, 최종제출 된 Application은 삭제되지 않습니다. - User Id: {}", userId);
+            } else {
+                applicationRepository.deleteById(application.getId());
+            }
         } else {
             log.warn("존재하지 않는 Application 삭제 요청 발생 - User Id: {}", userId);
         }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CascadeDeleteApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CascadeDeleteApplicationServiceImpl.java
@@ -1,0 +1,30 @@
+package team.themoment.hellogsm.web.domain.application.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsm.entity.domain.application.entity.Application;
+import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
+import team.themoment.hellogsm.web.domain.application.service.CascadeDeleteApplicationService;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CascadeDeleteApplicationServiceImpl implements CascadeDeleteApplicationService {
+    private final ApplicationRepository applicationRepository;
+
+    @Override
+    @Transactional(rollbackFor = {Exception.class})
+    public void execute(Long userId) {
+        final Optional<Application> optionalApplication = applicationRepository.findByUserId(userId);
+
+        if (optionalApplication.isPresent()) {
+            applicationRepository.deleteById(optionalApplication.get().getId());
+        } else {
+            log.warn("존재하지 않는 Application 삭제 요청 발생 - User Id: {}", userId);
+        }
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CascadeDeleteIdentityService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CascadeDeleteIdentityService.java
@@ -1,0 +1,5 @@
+package team.themoment.hellogsm.web.domain.identity.service;
+
+public interface CascadeDeleteIdentityService {
+    void execute(Long userId);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CascadeDeleteIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CascadeDeleteIdentityServiceImpl.java
@@ -1,0 +1,30 @@
+package team.themoment.hellogsm.web.domain.identity.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
+import team.themoment.hellogsm.web.domain.identity.service.CascadeDeleteIdentityService;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CascadeDeleteIdentityServiceImpl implements CascadeDeleteIdentityService {
+    private final IdentityRepository identityRepository;
+
+    @Override
+    @Transactional(rollbackFor = {Exception.class})
+    public void execute(Long userId) {
+        final Optional<Identity> optionalIdentity = identityRepository.findByUserId(userId);
+
+        if (optionalIdentity.isPresent()) {
+            identityRepository.deleteById(optionalIdentity.get().getId());
+        } else {
+            log.warn("존재하지 않는 Identity 삭제 요청 발생 - User Id: {}", userId);
+        }
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/controller/UserController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/controller/UserController.java
@@ -28,7 +28,7 @@ public class UserController {
     @DeleteMapping("/user/me")
     public ResponseEntity<Map<String,String>> delete() {
         deleteUserService.execute(manager.getId());
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("massage","삭제되었습니다."));
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message","삭제되었습니다."));
     }
 
     @GetMapping("/user/{userId}")

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/controller/UserController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/controller/UserController.java
@@ -3,13 +3,13 @@ package team.themoment.hellogsm.web.domain.user.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import team.themoment.hellogsm.web.domain.user.dto.domain.UserDto;
+import team.themoment.hellogsm.web.domain.user.service.DeleteUserService;
 import team.themoment.hellogsm.web.domain.user.service.UserByIdQuery;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/user/v1")
@@ -17,11 +17,18 @@ import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager
 public class UserController {
     private final AuthenticatedUserManager manager;
     private final UserByIdQuery userByIdQuery;
+    private final DeleteUserService deleteUserService;
 
     @GetMapping("/user/me")
     public ResponseEntity<UserDto> find() {
         UserDto userDto = userByIdQuery.execute(manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(userDto);
+    }
+
+    @DeleteMapping("/user/me")
+    public ResponseEntity<Map<String,String>> delete() {
+        deleteUserService.execute(manager.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("massage","삭제되었습니다."));
     }
 
     @GetMapping("/user/{userId}")

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/event/DeleteUserEventHandler.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/event/DeleteUserEventHandler.java
@@ -1,0 +1,24 @@
+package team.themoment.hellogsm.web.domain.user.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import team.themoment.hellogsm.entity.domain.user.event.DeleteUserEvent;
+import team.themoment.hellogsm.web.domain.application.service.CascadeDeleteApplicationService;
+import team.themoment.hellogsm.web.domain.identity.service.CascadeDeleteIdentityService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeleteUserEventHandler {
+    private final CascadeDeleteIdentityService cascadeDeleteIdentityService;
+    private final CascadeDeleteApplicationService cascadeDeleteApplicationService;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void deleteUserEventHandler(DeleteUserEvent event) {
+        cascadeDeleteIdentityService.execute(event.user().getId());
+        cascadeDeleteApplicationService.execute(event.user().getId());
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/DeleteUserService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/DeleteUserService.java
@@ -1,0 +1,5 @@
+package team.themoment.hellogsm.web.domain.user.service;
+
+public interface DeleteUserService {
+    void execute(Long userId);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/DeleteUserServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/DeleteUserServiceImpl.java
@@ -1,0 +1,28 @@
+package team.themoment.hellogsm.web.domain.user.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.themoment.hellogsm.entity.domain.user.entity.User;
+import team.themoment.hellogsm.entity.domain.user.event.DeleteUserEvent;
+import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
+import team.themoment.hellogsm.web.domain.user.service.DeleteUserService;
+import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(rollbackFor = {Exception.class})
+public class DeleteUserServiceImpl implements DeleteUserService {
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Override
+    public void execute(Long userId) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("존재하지 않는 사용자입니다.", HttpStatus.BAD_REQUEST));
+        userRepository.deleteById(user.getId());
+        applicationEventPublisher.publishEvent(new DeleteUserEvent(user));
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -142,6 +142,10 @@ public class SecurityConfig {
                         Role.ROLE_UNAUTHENTICATED.getRole(),
                         Role.ROLE_USER.getRole()
                 )
+                .requestMatchers(HttpMethod.DELETE, "/user/v1/user/me").hasAnyRole(
+                        Role.ROLE_UNAUTHENTICATED.getRole(),
+                        Role.ROLE_USER.getRole()
+                )
                 .requestMatchers(HttpMethod.GET, "/user/v1/user/*").hasAnyRole(
                         Role.ROLE_ADMIN.getRole()
                 )


### PR DESCRIPTION
## 개요

유저 탈퇴 기능을 추가하였습니다. 

## 본문

유저 탈퇴 시, 최종제출 된 원서를 제외하고 유저의 모든 데이터(본인인증, 원서)가 삭제됩니다.

### 추가 

- User 삭제 시 `DeleteUserEvent` 이벤트가 발생되며 관련된 데이터를 삭제합니다.
- `DeleteUserService` 정의 및 구현
- `CascadeDeleteIdentityService` 정의 및 구현
- `CascadeDeleteApplicationService` 정의 및 구현
- `SecurityConfig` : 유저 탈퇴 api 권한 제한 추가
- `UserController` : `delete()` 메서드 추가
- `UserControllerTest ` : `UserController#delete` 테스트코드 추가
- `index.adoc` : 유저 탈퇴 api 문서 추가

### 기타

개발하면서 기존에 원서 삭제 서비스를 재사용하려고 했는데, spring transation 관련한 에러때문에 객체를 추가할 수 밖에 없었음...
뭐가 문제였는지는 issue #177 을 참고

지금 동일한 로직이 중복해서 관리되고 있는 상황이라 나중에 시간 날때 중복된 로직을 가지는 서비스를 통합해야 함
