### PR TITLE
접수번호 할당 배치 프로세스 로직에서 누락된 컬럼 추가

### DIFF
--- a/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/setRegistrationNumber/SetRegistrationNumberJobConfig.java
+++ b/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/setRegistrationNumber/SetRegistrationNumberJobConfig.java
@@ -160,6 +160,8 @@ public class SetRegistrationNumberJobConfig {
                     .firstEvaluation(admissionStatus.getFirstEvaluation())
                     .secondEvaluation(admissionStatus.getSecondEvaluation())
                     .registrationNumber(null)
+                    .screeningFirstEvaluationAt(OptionalUtils.fromOptional(admissionStatus.getScreeningFirstEvaluationAt()))
+                    .screeningFirstEvaluationAt(OptionalUtils.fromOptional(admissionStatus.getScreeningSecondEvaluationAt()))
                     .secondScore(OptionalUtils.fromOptional(admissionStatus.getSecondScore()))
                     .finalMajor(OptionalUtils.fromOptional(admissionStatus.getFinalMajor()))
                     .build();
@@ -182,6 +184,8 @@ public class SetRegistrationNumberJobConfig {
                     .firstEvaluation(admissionStatus.getFirstEvaluation())
                     .secondEvaluation(admissionStatus.getSecondEvaluation())
                     .registrationNumber(registrationNumber)
+                    .screeningFirstEvaluationAt(OptionalUtils.fromOptional(admissionStatus.getScreeningFirstEvaluationAt()))
+                    .screeningFirstEvaluationAt(OptionalUtils.fromOptional(admissionStatus.getScreeningSecondEvaluationAt()))
                     .secondScore(OptionalUtils.fromOptional(admissionStatus.getSecondScore()))
                     .finalMajor(OptionalUtils.fromOptional(admissionStatus.getFinalMajor()))
                     .build();


### PR DESCRIPTION
## 개요

접수번호 할당 배치 프로세스 로직의 `AdmissionStatus` 객체 빌더에서
누락된 컬럼 `screeningFirstEvaluationAt`, `screeningSecondEvaluationAt`를 할당하도록 수정하였습니다.