### PR TITLE
어드민 로그인 시 어드민 페이지로 리다이렉트 기능 추가

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -113,7 +113,7 @@ public class SecurityConfig {
                 oauth2Login
                         .authorizationEndpoint().baseUri(oauth2LoginEndpointBaseUri).and()
                         .loginProcessingUrl(oauth2LoginProcessingUri)
-                        .successHandler(new CustomUrlAuthenticationSuccessHandler(authEnv.redirectBaseUri()))
+                        .successHandler(new CustomUrlAuthenticationSuccessHandler(authEnv.redirectBaseUri(), authEnv.redirectAdminUri()))
                         .failureHandler(new SimpleUrlAuthenticationFailureHandler(authEnv.redirectLoginFailureUri()))
 
         );

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthEnvironment.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthEnvironment.java
@@ -15,6 +15,7 @@ import java.util.List;
 @ConfigurationProperties(prefix = "auth")
 public record AuthEnvironment(
         String redirectBaseUri,
+        String redirectAdminUri,
         String redirectLoginFailureUri,
         List<String> allowedOrigins
 ) {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/handler/CustomUrlAuthenticationSuccessHandler.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/handler/CustomUrlAuthenticationSuccessHandler.java
@@ -11,13 +11,16 @@ import org.springframework.web.util.UriComponentsBuilder;
 import team.themoment.hellogsm.entity.domain.user.enums.Role;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 public class CustomUrlAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
     private final String defaultTargetUrl;
+    private final String adminUrl;
 
-    public CustomUrlAuthenticationSuccessHandler(String defaultTargetUrl) {
+    public CustomUrlAuthenticationSuccessHandler(String defaultTargetUrl, String adminUrl) {
         this.defaultTargetUrl = defaultTargetUrl;
+        this.adminUrl = adminUrl;
     }
 
     @Override
@@ -26,8 +29,11 @@ public class CustomUrlAuthenticationSuccessHandler implements AuthenticationSucc
         boolean isUnAuthentication = authentication.getAuthorities().stream()
                 .anyMatch(authority -> Role.ROLE_UNAUTHENTICATED.name().equals(authority.getAuthority()));
 
+        boolean isAdmin = authentication.getAuthorities().stream()
+                .anyMatch(authority -> Role.ROLE_ADMIN.name().equals(authority.getAuthority()));
+
         String redirectUrlWithParameter = UriComponentsBuilder
-                .fromUriString(defaultTargetUrl)
+                .fromUriString(getTargetUrl(isAdmin))
                 .queryParam("verification", !isUnAuthentication)
                 .build()
                 .toUriString();
@@ -35,6 +41,14 @@ public class CustomUrlAuthenticationSuccessHandler implements AuthenticationSucc
         response.sendRedirect(redirectUrlWithParameter);
 
         clearAuthenticationAttributes(request);
+    }
+
+    protected final String getTargetUrl(boolean isAdmin) {
+        if (isAdmin) {
+            return adminUrl;
+        } else {
+            return defaultTargetUrl;
+        }
     }
 
     protected final void clearAuthenticationAttributes(HttpServletRequest request) {


### PR DESCRIPTION
## 개요

어드민이 로그인 시 어드민 페이지로 리다이렉트 되는 기능을 추가하였습니다.

## 본문

### 추가 

- `AuthEnvironment` 어드민 리다이렉트 페이지 변수 추가

### 변경

- `CustomUrlAuthenticationSuccessHandler`
  - 어드민 리다이렉트 페이지 변수 추가
  - 리다이렉트 주소를 구하는 `getTargetUrl` 메서드 추가
