### PR TITLE
특정 기간 내 요청만 허용하는 Filter 구현

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/HellogsmWebApplication.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/HellogsmWebApplication.java
@@ -5,10 +5,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import team.themoment.hellogsm.web.global.security.auth.AuthEnvironment;
+import team.themoment.hellogsm.web.global.security.schedule.ScheduleEnvironment;
 
 @EnableAspectJAutoProxy
 @SpringBootApplication
-@EnableConfigurationProperties({AuthEnvironment.class})
+@EnableConfigurationProperties({AuthEnvironment.class, ScheduleEnvironment.class})
 public class HellogsmWebApplication {
 
     public static void main(String[] args) {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/filter/TimeBasedFilter.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/filter/TimeBasedFilter.java
@@ -73,7 +73,7 @@ public class TimeBasedFilter extends OncePerRequestFilter {
 
     private void sendErrorResponse(HttpServletResponse response, String message) throws IOException {
         response.setCharacterEncoding("utf-8");
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setStatus(HttpStatus.FORBIDDEN.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         Map<String, Object> map = new HashMap<>();
         map.put("message", message);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/filter/TimeBasedFilter.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/filter/TimeBasedFilter.java
@@ -61,11 +61,14 @@ public class TimeBasedFilter extends OncePerRequestFilter {
                 filterChain.doFilter(request, response);
                 return;
             } else {
-                String message = String.format("요청이 거부되었습니다. 현재 시간: %s, 해당 요청은 %s ~ %s 이내에만 처리 가능합니다.", currentTime, timeRange.startTime, timeRange.endTime);
+                String message = String.format("%s 요청이 거부되었습니다. " +
+                        "현재 시간: %s, 해당 요청은 %s ~ %s 이내에만 처리 가능합니다.", constraintKey, currentTime, timeRange.startTime, timeRange.endTime);
                 log.warn(message);
                 sendErrorResponse(response, message);
+                return;
             }
         }
+        filterChain.doFilter(request, response);
     }
 
     private void sendErrorResponse(HttpServletResponse response, String message) throws IOException {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/filter/TimeBasedFilter.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/filter/TimeBasedFilter.java
@@ -36,7 +36,7 @@ public class TimeBasedFilter extends OncePerRequestFilter {
         }
     }
 
-    public TimeBasedFilter addTimeConstraint(String url, HttpMethod httpMethod, LocalDateTime startTime, LocalDateTime endTime) {
+    public TimeBasedFilter addTimeConstraint(HttpMethod httpMethod, String url, LocalDateTime startTime, LocalDateTime endTime) {
         urlTimeConstraints.put(url + ":" + httpMethod, new TimeRange(startTime, endTime));
         return this;
     }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/filter/TimeBasedFilter.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/filter/TimeBasedFilter.java
@@ -1,0 +1,69 @@
+package team.themoment.hellogsm.web.global.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class TimeBasedFilter extends OncePerRequestFilter {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private final Map<String, TimeRange> urlTimeConstraints = new HashMap<>();
+
+    private static class TimeRange {
+        private final LocalDateTime startTime;
+        private final LocalDateTime endTime;
+
+        public TimeRange(LocalDateTime startTime, LocalDateTime endTime) {
+            this.startTime = startTime;
+            this.endTime = endTime;
+        }
+
+        public boolean isWithinRange(LocalDateTime currentTime) {
+            return currentTime.isAfter(startTime) && currentTime.isBefore(endTime);
+        }
+    }
+
+    public TimeBasedFilter addTimeConstraint(String url, LocalDateTime startTime, LocalDateTime endTime) {
+        urlTimeConstraints.put(url, new TimeRange(startTime, endTime));
+        return this;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String requestUrl = request.getRequestURI();
+        LocalDateTime currentTime = LocalDateTime.now();
+
+        if (urlTimeConstraints.containsKey(requestUrl)) {
+            TimeRange timeRange = urlTimeConstraints.get(requestUrl);
+            if (timeRange.isWithinRange(currentTime)) {
+                filterChain.doFilter(request, response);
+                return;
+            } else {
+                String message = String.format("요청이 거부되었습니다. 현재 시간: %s, 해당 요청은 %s ~ %s 이내에만 처리 가능합니다.", currentTime, timeRange.startTime, timeRange.endTime);
+                log.warn(message);
+                sendErrorResponse(response, message);
+            }
+        }
+    }
+
+    private void sendErrorResponse(HttpServletResponse response, String message) throws IOException {
+        response.setCharacterEncoding("utf-8");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        Map<String, Object> map = new HashMap<>();
+        map.put("message", message);
+        response.getWriter().write(objectMapper.writeValueAsString(map));
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/schedule/ScheduleEnvironment.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/schedule/ScheduleEnvironment.java
@@ -1,0 +1,16 @@
+package team.themoment.hellogsm.web.global.security.schedule;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@ConfigurationProperties(prefix = "schedule")
+public record ScheduleEnvironment (
+        LocalDate startReceptionDate,
+        LocalDate endReceptionDate,
+        LocalDate firstEvaluationAnnouncementDate,
+        LocalDate finalEvaluationRunDate,
+        LocalDate finalResultAnnouncementDate
+) {
+}

--- a/hellogsm-web/src/main/resources/schedule.yml
+++ b/hellogsm-web/src/main/resources/schedule.yml
@@ -1,0 +1,6 @@
+schedule:
+  start-reception-date: 2023-10-16
+  end-reception-date: 2023-10-19
+  first-evaluation-announcement-date: 2023-10-23
+  final-evaluation-run-date: 2023-10-27
+  final-result-announcement-date: 2023-11-1

--- a/hellogsm-web/src/main/resources/schedule.yml
+++ b/hellogsm-web/src/main/resources/schedule.yml
@@ -3,4 +3,4 @@ schedule:
   end-reception-date: 2023-10-19
   first-evaluation-announcement-date: 2023-10-23
   final-evaluation-run-date: 2023-10-27
-  final-result-announcement-date: 2023-11-1
+  final-result-announcement-date: 2023-11-01


### PR DESCRIPTION
## 개요

특정 기간 내의 요청을 처리하는 Filter를 구현하였습니다.
원서 접수 기간 이후 처리되지 않아야 하는 요청을 block하기 위해 만들었습니다.

## 본문

### 추가
- `schedule.yml`, `ScheduleEnvironment`
  - 기간 정보가 담긴 객체, config 파일을 생성
- `TimeBasedFilter`
  - 특정 기간 내 요청만 통과시키는 filter입니다.
  - 특정 url, http method를 포함하는 경우 조건을 확인하도록 구현하였습니다.
- `HellogsmWebApplication`
  - `@EnableConfigurationProperties` 에`ScheduleEnvironment` 추가
- `SecurityConfig`
  - `TimeBasedFilter` 설정 및 Bean 등록
  - 운영 환경에서만 필터가 등록되도록 설정하였음