### PR TITLE
[#192] AdmissionGrade의 최대, 최소 지우기

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGrade.java
@@ -32,14 +32,10 @@ public abstract class AdmissionGrade {
     protected Long id;
 
     @Digits(integer = 3, fraction = 3)
-    @DecimalMin(value = "78")
-    @DecimalMax(value = "300")
     @Column(name = "total_score", nullable = false)
     protected BigDecimal totalScore;
 
     @Digits(integer = 2, fraction = 3)
-    @DecimalMin(value = "0")
-    @DecimalMax(value = "74")
     @Column(name = "percentile_rank", nullable = false)
     protected BigDecimal percentileRank;
 }


### PR DESCRIPTION
## 개요

AdmissionGrade에 있는 totalScore, percentileRank 값들은 검정고시의 경우 최대, 최소값이 없어지기 때문에 제한을 지웠습니다

## 본문

AdmissionGrade의 DecimalMin과 DecimalMax를 지웠습니다