### PR TITLE
원서 검색 기능 구현

### DIFF
--- a/hellogsm-web/src/docs/asciidoc/index.adoc
+++ b/hellogsm-web/src/docs/asciidoc/index.adoc
@@ -390,6 +390,15 @@ operation::identity/identity/modify-by-authenticated[snippets='http-response']
 |`SPECIAL_VETERANS`| [정원 외 특별전형] 국가보훈대상자
 |`SPECIAL_ADMISSION`| [정원 외 특별전형] 특례입학대상자
 |====
+==== SearchTag
+검색 조건
+[cols="2,3"]
+|====
+|Name |설명
+|`APPLICANT`| 지원자 이름
+|`SCHOOL`| 지원자 학교
+|`PHONE_NUMBER`| 전화번호 (지원자, 보호자, 선생님 전부)
+|====
 
 === [GET] application/me
 현재 사용자의 원서 정보를 가져오는 엔드포인트입니다.
@@ -470,6 +479,15 @@ operation::application/delete-application[snippets='curl-request,http-request']
 
 ==== Response
 operation::application/delete-application[snippets='http-response']
+
+=== [GET] application/search
+최종제출이 완료된 사용자를 검색하는 엔드포인트입니다.
+
+==== Request
+operation::application/search[snippets='curl-request,http-request,query-parameters']
+
+==== Response
+operation::application/search[snippets='http-response,response-fields']
 
 === [GET] application/all
 모든 사용자의 원서를 조회하는 엔드포인트입니다.

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -5,7 +5,9 @@ import org.springframework.web.multipart.MultipartFile;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.ApplicationListDto;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationStatusReqDto;
+import team.themoment.hellogsm.web.domain.application.dto.response.SearchApplicationsResDto;
 import team.themoment.hellogsm.web.domain.application.dto.response.SingleApplicationRes;
+import team.themoment.hellogsm.web.domain.application.enums.SearchTag;
 import team.themoment.hellogsm.web.domain.application.service.ApplicationListQuery;
 import team.themoment.hellogsm.web.domain.application.service.CreateApplicationService;
 import team.themoment.hellogsm.web.domain.application.service.DeleteApplicationService;
@@ -38,6 +40,7 @@ public class ApplicationController {
     private final CreateApplicationService createApplicationService;
     private final ModifyApplicationService modifyApplicationService;
     private final QuerySingleApplicationService querySingleApplicationService;
+    private final SearchApplicationsService searchApplicationsService;
     private final ApplicationListQuery applicationListQuery;
     private final ModifyApplicationStatusService modifyApplicationStatusService;
     private final DeleteApplicationService deleteApplicationService;
@@ -79,6 +82,24 @@ public class ApplicationController {
         if (page < 0 || size < 0)
             throw new ExpectedException("0 이상만 가능합니다", HttpStatus.BAD_REQUEST);
         return ResponseEntity.status(HttpStatus.OK).body(applicationListQuery.execute(page, size));
+    }
+
+    @GetMapping("/application/search")
+    public ResponseEntity<SearchApplicationsResDto> findAll(
+            @RequestParam("page") Integer page,
+            @RequestParam("size") Integer size,
+            @RequestParam("tag") String tag,
+            @RequestParam("keyword") String keyword
+    ) {
+        if (page < 0 || size < 0)
+            throw new ExpectedException("0 이상만 가능합니다", HttpStatus.BAD_REQUEST);
+        SearchTag searchTag = null;
+        try {
+            searchTag = SearchTag.valueOf(tag);
+        } catch (IllegalArgumentException e) {
+            throw new ExpectedException("유효하지 않은 tag입니다", HttpStatus.BAD_REQUEST);
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(searchApplicationsService.execute(page, size, searchTag, keyword));
     }
 
     @PutMapping("/status/{userId}")

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/SearchApplicationResDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/SearchApplicationResDto.java
@@ -1,0 +1,23 @@
+package team.themoment.hellogsm.web.domain.application.dto.response;
+
+import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
+import team.themoment.hellogsm.entity.domain.application.enums.Screening;
+
+import java.math.BigDecimal;
+
+public record SearchApplicationResDto(
+        Long applicationId,
+        Boolean isFinalSubmitted,
+        Boolean isPrintsArrived,
+        String applicantName,
+        Screening screening,
+        String schoolName,
+        String applicantPhoneNumber,
+        String guardianPhoneNumber,
+        String teacherPhoneNumber,
+        EvaluationStatus firstEvaluation,
+        EvaluationStatus secondEvaluation,
+        BigDecimal secondScore
+){
+
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/SearchApplicationsResDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/SearchApplicationsResDto.java
@@ -1,0 +1,8 @@
+package team.themoment.hellogsm.web.domain.application.dto.response;
+
+import java.util.List;
+
+public record SearchApplicationsResDto (
+    ApplicationListInfoDto info,
+    List<SearchApplicationResDto> applications
+) {}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/enums/SearchTag.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/enums/SearchTag.java
@@ -1,0 +1,7 @@
+package team.themoment.hellogsm.web.domain.application.enums;
+
+public enum SearchTag {
+    APPLICANT,
+    SCHOOL,
+    PHONE_NUMBER
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -280,4 +280,30 @@ public interface ApplicationMapper {
             @Mapping(source = "admissionInfo.desiredMajor.thirdDesiredMajor", target = "desiredMajor.thirdDesiredMajor"),
     })
     AdmissionInfo toConsistentAdmissionInfoWithIdentity(AdmissionInfo admissionInfo, Identity identity);
+
+    @BeanMapping(ignoreUnmappedSourceProperties = {"id", "middleSchoolGrade", "admissionGrade", "userId"})
+    @Mappings({
+            @Mapping(source = "admissionInfo.id", target = "applicationId"),
+            @Mapping(source = "admissionStatus.isFinalSubmitted", target = "isFinalSubmitted"),
+            @Mapping(source = "admissionStatus.isPrintsArrived", target = "isPrintsArrived"),
+            @Mapping(source = "admissionInfo.applicantName", target = "applicantName"),
+            @Mapping(source = "admissionInfo.screening", target = "screening"),
+            @Mapping(source = "admissionInfo.schoolName", target = "schoolName"),
+            @Mapping(source = "admissionInfo.applicantPhoneNumber", target = "applicantPhoneNumber"),
+            @Mapping(source = "admissionInfo.guardianPhoneNumber", target = "guardianPhoneNumber"),
+            @Mapping(source = "admissionInfo.teacherPhoneNumber", target = "teacherPhoneNumber"),
+            @Mapping(source = "admissionStatus.firstEvaluation", target = "firstEvaluation"),
+            @Mapping(source = "admissionStatus.secondEvaluation", target = "secondEvaluation"),
+            @Mapping(source = "admissionStatus.secondScore", target = "secondScore"),
+    })
+    SearchApplicationResDto applicationToSearchApplicationResDto(Application application);
+
+    List<SearchApplicationResDto> applicationsToSearchApplicationResDtos(List<Application> applications);
+
+    default SearchApplicationsResDto applicationsToSearchApplicationsResDto(List<Application> applications) {
+        return new SearchApplicationsResDto(
+                new ApplicationListInfoDto(applications.size()),
+                applicationsToSearchApplicationResDtos(applications)
+        );
+    }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
 import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
 
@@ -24,6 +25,17 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     Optional<Application> findByUserIdEagerFetch(Long userId);
 
     Page<Application> findAll(Pageable pageable);
+
+    Page<Application> findAllByAdmissionInfoApplicantNameContainingAndAdmissionStatus_IsFinalSubmitted(String keyword, Boolean isFinalSubmitted, Pageable pageable);
+
+    Page<Application> findAllByAdmissionInfoSchoolNameContainingAndAdmissionStatus_IsFinalSubmitted(String keyword, Boolean isFinalSubmitted, Pageable pageable);
+
+    @Query("SELECT a FROM Application a WHERE " +
+            "a.admissionInfo.applicantPhoneNumber LIKE %:keyword% OR " +
+            "a.admissionInfo.guardianPhoneNumber LIKE %:keyword% OR " +
+            "a.admissionInfo.teacherPhoneNumber LIKE %:keyword% AND " +
+            "a.admissionStatus.isFinalSubmitted = TRUE"  )
+    Page<Application> findAllByIsFinalSubmittedAndPhoneNumberContaining(@Param("keyword") String keyword, Pageable pageable);
 
     void deleteApplicationByUserId(Long userId);
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/SearchApplicationsService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/SearchApplicationsService.java
@@ -1,0 +1,8 @@
+package team.themoment.hellogsm.web.domain.application.service;
+
+import team.themoment.hellogsm.web.domain.application.dto.response.SearchApplicationsResDto;
+import team.themoment.hellogsm.web.domain.application.enums.SearchTag;
+
+public interface SearchApplicationsService {
+    SearchApplicationsResDto execute(Integer page, Integer size, SearchTag tag, String keyword);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/SearchApplicationsServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/SearchApplicationsServiceImpl.java
@@ -1,0 +1,34 @@
+package team.themoment.hellogsm.web.domain.application.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsm.entity.domain.application.entity.Application;
+import team.themoment.hellogsm.web.domain.application.dto.response.SearchApplicationsResDto;
+import team.themoment.hellogsm.web.domain.application.enums.SearchTag;
+import team.themoment.hellogsm.web.domain.application.mapper.ApplicationMapper;
+import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
+import team.themoment.hellogsm.web.domain.application.service.SearchApplicationsService;
+
+@Service
+@RequiredArgsConstructor
+public class SearchApplicationsServiceImpl implements SearchApplicationsService {
+    final ApplicationRepository applicationRepository;
+
+    @Override
+    public SearchApplicationsResDto execute(Integer page, Integer size, SearchTag tag, String keyword) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        return ApplicationMapper.INSTANCE.applicationsToSearchApplicationsResDto(applicationPage(tag, keyword, pageable).getContent());
+    }
+
+    public Page<Application> applicationPage(SearchTag tag, String keyword, Pageable pageable) {
+        return switch (tag) {
+            case APPLICANT -> applicationRepository.findAllByAdmissionInfoApplicantNameContainingAndAdmissionStatus_IsFinalSubmitted(keyword, true, pageable);
+            case SCHOOL -> applicationRepository.findAllByAdmissionInfoSchoolNameContainingAndAdmissionStatus_IsFinalSubmitted(keyword, true, pageable);
+            case PHONE_NUMBER -> applicationRepository.findAllByIsFinalSubmittedAndPhoneNumberContaining(keyword, pageable);
+        };
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -200,6 +200,7 @@ public class SecurityConfig {
                         HttpMethod.GET,
                         "/application/v1/ticket",
                         "/application/v1/application/all",
+                        "/application/v1/application/search",
                         "/application/v1/application/*"
                 ).hasAnyRole(
                         Role.ROLE_ADMIN.getRole()


### PR DESCRIPTION
## 개요

원서를 검색하여 조회 할 수 있는 기능을 추가하였습니다.

## 본문

### 추가 

- `SearchApplicationResDto`, `SearchApplicationsResDto`
  - 원서 검색 결과 정보를 가지고 있는 DTO입니다.
- `SearchTag`
  - 원서 검색 조건 정보를 가지는 Enum
- `SearchApplicationsService`. `SearchApplicationsServiceImpl`
  -원서 검색 서비스 객체

### 변경 

- `ApplicationController`
  - 원서 검색 url(`application/search`)를 매핑하는 메서드 추가
- `ApplicationRepository`
  - 원서 조건 별 검색 쿼리 메서드 추가
- `ApplicationControllerTest`
  - 원서 검색 기능 테스트코드 추가
- `SecurityConfig`
  - 원서 검색 url 설정 추가
- `index.adoc`
  - 원서 검색 관련 정보(api, enum) API 명세서에 작성
