### PR TITLE
fix: `identity/me/send-code-test` api 보안 설정 에러 해결

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -76,7 +76,7 @@ public class SecurityConfig {
             oauth2Login(http);
             http.authorizeHttpRequests(
                     httpRequests -> httpRequests
-                            .requestMatchers(HttpMethod.GET, "/identity/v1/identity/me/send-code-test")
+                            .requestMatchers(HttpMethod.POST, "/identity/v1/identity/me/send-code-test")
                             .hasAnyRole(
                                     Role.ROLE_UNAUTHENTICATED.getRole(),
                                     Role.ROLE_USER.getRole())
@@ -177,7 +177,6 @@ public class SecurityConfig {
                 .requestMatchers(
                         HttpMethod.POST,
                         "/identity/v1/identity/me/send-code",
-                        "/identity/v1/identity/me/send-code-test",
                         "/identity/me/auth-code").hasAnyRole(
                         Role.ROLE_UNAUTHENTICATED.getRole(),
                         Role.ROLE_USER.getRole()


### PR DESCRIPTION
## 개요

`/identity/v1/identity/me/send-code-test` api의 보안 설정 문제를 해결하였습니다.

## 본문

dev, local 환경에서만 실행 가능하도록 변경하였고, http method가 달라 적용이 되지 않던 문제를 해결하였습니다.
