### PR TITLE
원서 리스트 검색 시 tag 없이 조회 가능한 기능 추가

### DIFF
--- a/hellogsm-web/src/docs/asciidoc/index.adoc
+++ b/hellogsm-web/src/docs/asciidoc/index.adoc
@@ -484,7 +484,11 @@ operation::application/delete-application[snippets='http-response']
 최종제출이 완료된 사용자를 검색하는 엔드포인트입니다.
 
 ==== Request
-operation::application/search[snippets='curl-request,http-request,query-parameters']
+operation::application/search[snippets='curl-request,http-request']
+operation::application/search[snippets='query-parameters']
+WARNING: `tag` 파라미터를 사용하지 않는 경우, `keyword` 파라미터의 값은 무시됩니다.
+
+
 
 ==== Response
 operation::application/search[snippets='http-response,response-fields']

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -88,14 +88,16 @@ public class ApplicationController {
     public ResponseEntity<SearchApplicationsResDto> findAll(
             @RequestParam("page") Integer page,
             @RequestParam("size") Integer size,
-            @RequestParam("tag") String tag,
-            @RequestParam("keyword") String keyword
+            @RequestParam(name = "tag", required = false) String tag,
+            @RequestParam(name = "keyword", required = false) String keyword
     ) {
         if (page < 0 || size < 0)
             throw new ExpectedException("0 이상만 가능합니다", HttpStatus.BAD_REQUEST);
         SearchTag searchTag = null;
         try {
-            searchTag = SearchTag.valueOf(tag);
+            if (tag != null) {
+                searchTag = SearchTag.valueOf(tag);
+            }
         } catch (IllegalArgumentException e) {
             throw new ExpectedException("유효하지 않은 tag입니다", HttpStatus.BAD_REQUEST);
         }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
@@ -37,6 +37,8 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
             "a.admissionStatus.isFinalSubmitted = TRUE"  )
     Page<Application> findAllByIsFinalSubmittedAndPhoneNumberContaining(@Param("keyword") String keyword, Pageable pageable);
 
+    Page<Application> findAllByAdmissionStatusIsFinalSubmitted(Boolean isFinalSubmitted, Pageable pageable);
+
     void deleteApplicationByUserId(Long userId);
 
     List<Application> findAllByAdmissionStatus_FirstEvaluation(EvaluationStatus evaluationStatus);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/SearchApplicationsServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/SearchApplicationsServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,12 +20,15 @@ public class SearchApplicationsServiceImpl implements SearchApplicationsService 
     final ApplicationRepository applicationRepository;
 
     @Override
-    public SearchApplicationsResDto execute(Integer page, Integer size, SearchTag tag, String keyword) {
+    public SearchApplicationsResDto execute(Integer page, Integer size, @Nullable SearchTag tag, @Nullable String keyword) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
         return ApplicationMapper.INSTANCE.applicationsToSearchApplicationsResDto(applicationPage(tag, keyword, pageable).getContent());
     }
 
     public Page<Application> applicationPage(SearchTag tag, String keyword, Pageable pageable) {
+        if (tag == null) {
+            return applicationRepository.findAllByAdmissionStatusIsFinalSubmitted(true, pageable);
+        }
         return switch (tag) {
             case APPLICANT -> applicationRepository.findAllByAdmissionInfoApplicantNameContainingAndAdmissionStatus_IsFinalSubmitted(keyword, true, pageable);
             case SCHOOL -> applicationRepository.findAllByAdmissionInfoSchoolNameContainingAndAdmissionStatus_IsFinalSubmitted(keyword, true, pageable);

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -595,8 +595,8 @@ class ApplicationControllerTest {
                         queryParameters(
                                 parameterWithName("page").description("페이지"),
                                 parameterWithName("size").description("원서 크기"),
-                                parameterWithName("tag").description("검색 태그"),
-                                parameterWithName("keyword").description("검색 키워드")
+                                parameterWithName("tag").description("[Optional] 검색 태그"),
+                                parameterWithName("keyword").description("[Optional] 검색 키워드")
                         ),
                         requestSessionCookie(),
                         responseFields(


### PR DESCRIPTION
## 개요

원서 리스트 검색 시 tag 없이도 조회가 가능하도록 기능을 추가하였습니다.

## 본문

### 추가
- `SearchApplicationsServiceImpl`, `ApplicationController` : tag와 keword가 null인 경우를 처리하는 로직 추가
- `ApplicationRepository` : 최종제출이 완료된 모든 application을 조회하는 메서드 추가

### 변경 - optional
- `index.adoc`, `ApplicationControllerTest` : api 파라미터 설명 보완