### PR TITLE
[#197] ApplicationMapper 일부 필드 누락된 문제 해결

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -235,6 +235,8 @@ public interface ApplicationMapper {
                 .teacherName(applicationReqDto.teacherName())
                 .teacherPhoneNumber(applicationReqDto.teacherPhoneNumber())
                 .screening(Screening.valueOf(applicationReqDto.screening()))
+                .schoolName(applicationReqDto.schoolName())
+                .schoolLocation(applicationReqDto.schoolLocation())
                 .desiredMajor(desiredMajor)
                 .build();
 


### PR DESCRIPTION
## 개요
`ApplicationMapper#applicationReqDtoAndIdentityDtoToApplication`에서 일부 필드 누락된 문제를 해결하였습니다.
자세한 내용은 #197 참고

## 본문

`ApplicationMapper#applicationReqDtoAndIdentityDtoToApplication`에 누락된 `schoolName`과 `schoolLocation` 값 할당 구문 추가