### PR TITLE
엔티티 모듈 객체 javadoc `@author`, `@since` 태그 삭제

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/Application.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/Application.java
@@ -15,9 +15,6 @@ import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
  * 원서의 신청 정보를 저장하는 Entity입니다. <br>
  * cascade = CascadeType.ALL, orphanRemoval = true 설정으로 관련된 엔티티들의 라이프사이클을 관리합니다.
  * FetchType.LAZY 설정으로 필요한 경우에만 연관된 엔티티를 로딩합니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 @Entity
 @Table(name = "application")

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/AdmissionInfo.java
@@ -13,11 +13,7 @@ import java.util.Optional;
 
 /**
  * 입학 원서의 인적사항을 저장하는 Entity입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
-
 @Entity
 @Table(name = "admission_info")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/DesiredMajor.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/admission/DesiredMajor.java
@@ -15,9 +15,6 @@ import java.util.Set;
 
 /**
  * {@code AdmissionInfo}의 희망 학과를 저장하는 embedded type입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 
 @Embeddable

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGrade.java
@@ -11,9 +11,6 @@ import java.math.BigDecimal;
 
 /**
  * 학생의 입학 원서 성적을 저장하는 슈퍼타입의 Entity입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 @Entity
 @Table(name = "admission_grade")

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGradeFactory.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGradeFactory.java
@@ -5,9 +5,6 @@ import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
 
 /**
  * 입학 원서의 성적을 {@code AdmissionGrade}의 구현체를 생성하는 팩토리 클래스입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 @RequiredArgsConstructor
 public class AdmissionGradeFactory {

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GedAdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GedAdmissionGrade.java
@@ -20,9 +20,6 @@ import static lombok.AccessLevel.PROTECTED;
 
 /**
  * 검정고시 학생의 입학 원서 성적을 저장하는 서브타입의 Entity입니다.
- *
- * @author 양시준, 변찬우
- * @since 1.0.0
  */
 @Entity
 @NoArgsConstructor(access = PROTECTED)

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
@@ -20,9 +20,6 @@ import java.util.stream.Stream;
 
 /**
  * 졸업예정, 졸업 학생의 입학 원서 성적을 저장하는 서브타입의 Entity입니다.
- *
- * @author 양시준, 변찬우
- * @since 1.0.0
  */
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/MiddleSchoolGrade.java
@@ -5,9 +5,6 @@ import lombok.*;
 
 /**
  * 학생의 입학 중학교 성적을 저장하는 Entity입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 @Entity
 @Table(name = "middle_school_grade")

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/data/GeneralScoreData.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/data/GeneralScoreData.java
@@ -5,9 +5,6 @@ import java.util.List;
 
 /**
  * 학기별 성적을 저장하는 record 입니다
- *
- * @author 변찬우
- * @since 1.0.0
  */
 public record GeneralScoreData(
         List<BigDecimal> score1_1,

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/status/AdmissionStatus.java
@@ -12,9 +12,6 @@ import java.util.Optional;
 
 /**
  * 입학 원서의 상태를 저장하는 Entity입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/enums/EvaluationStatus.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/enums/EvaluationStatus.java
@@ -2,9 +2,6 @@ package team.themoment.hellogsm.entity.domain.application.enums;
 
 /**
  * 평가 상태를 나타내는 enum class 입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 public enum EvaluationStatus {
     NOT_YET,

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/enums/Gender.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/enums/Gender.java
@@ -2,9 +2,6 @@ package team.themoment.hellogsm.entity.domain.application.enums;
 
 /**
  * 성별을 나타내는 enum class 입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 public enum Gender {
     MALE,

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/enums/GraduationStatus.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/enums/GraduationStatus.java
@@ -2,9 +2,6 @@ package team.themoment.hellogsm.entity.domain.application.enums;
 
 /**
  * 지원자의 졸업 상태를 나타내는 enum class 입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 public enum GraduationStatus {
     CANDIDATE,

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/enums/Major.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/enums/Major.java
@@ -2,9 +2,6 @@ package team.themoment.hellogsm.entity.domain.application.enums;
 
 /**
  * 학교의 학과를 나타내는 enum class 입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 public enum Major {
     AI,

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/identity/entity/Identity.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/identity/entity/Identity.java
@@ -10,9 +10,6 @@ import team.themoment.hellogsm.entity.domain.identity.event.UpdateIdentityEvent;
 
 /**
  * 본인인증 정보를 저장하는 Identity Entity입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 @Entity
 @Table(name = "identity")


### PR DESCRIPTION
## 개요

엔티티 관련 객체 javadoc에서 `@author`, `@since` 태그를 삭제하였습니다.

## 본문

### 변경

#### `@author` 태그 삭제 이유
- 매 년 새로운 팀원이 들어오고 나가는 상황에서 최신 상황으로 관리하기 어려움
- author가 지정되어 있어 다른 팀원이 신경을 덜 쓰게 될 수 있음
- 코드 작성자나 변경 확인은 IDE에서 지원하는 github 관련 기능으로도 문제 없이 가능

#### `@since` 태그 삭제 이유
- 사용의미가 없음
  - 프로그램이나 라이브러리처럼 버전 별로 관리하는 프로젝트가 아님

## 기타

[Javadoc @author 태그 사용을 멈추자](https://octob.medium.com/javadoc-author-%ED%83%9C%EA%B7%B8-%EC%82%AC%EC%9A%A9%EC%9D%84-%EA%B7%B8%EB%A7%8C%ED%95%98%EC%9E%90-cc4cad7c671e) 포스팅이 결정에 영향을 줬고, 좋은 글이라고 생각하니까 읽어보는걸 추천