### PR TITLE
`AdmissionGradeFactory#create` 에러 문구 수정

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGradeFactory.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/AdmissionGradeFactory.java
@@ -26,7 +26,7 @@ public class AdmissionGradeFactory {
         } else if (graduationStatus.equals(GraduationStatus.GED)) {
             return new GedAdmissionGrade(middleSchoolGrades);
         } else {
-            throw new IllegalArgumentException("원서의 졸업싱태와 중학교 성적의 형식이 일치하지 않습니다.");
+            throw new IllegalArgumentException("지원하지 않는 GraduationStatus Type 입니다. GraduationStatus : " + graduationStatus);
         }
     }
 }


### PR DESCRIPTION
## 개요

`AdmissionGradeFactory#create` 에러 문구가 상황에 올바른 설명이 아니여서 수정하였습니다.

## 본문

`AdmissionGradeFactory#create`는 GraduationStatus Type에 따라 각자 다른 객체를 생성하고, 지원하는 GraduationStatus Type이 아닌 경우 에러가 발생하는데, 아래와 같은 문구가 출력됩니다.
> "원서의 졸업싱태와 중학교 성적의 형식이 일치하지 않습니다."

해당 문구는 문제 상황을 잘 표현하지 못하고 있습니다.

문제 상황과 어떤 값이 문제를 발생시키는지 확인 가능하도록 에러 문구를 수정하였습니다.
