### PR TITLE
Web 모듈 객체 Javadoc `@author`, `@since` 태그 삭제

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/annotation/NotSpace.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/annotation/NotSpace.java
@@ -7,9 +7,6 @@ import java.lang.annotation.*;
 
 /**
  * null은 허용하지만 공백과 빈 문자열은 허용하지 않음
- *
- * @author 변찬우
- * @since 1.0.0
  */
 @Documented
 @Constraint(validatedBy = NotSpaceValidator.class)

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -28,9 +28,6 @@ import java.util.Map;
 
 /**
  * 원서를 관리하는 controller 입니다
- *
- * @author 변찬우
- * @since 1.0.0
  */
 @RestController
 @RequiredArgsConstructor

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationReqDto.java
@@ -11,9 +11,6 @@ import java.util.Set;
 
 /**
  * 원서 생성을 담당하는 dto 입니다
- *
- * @author 변찬우
- * @since 1.0.0
  */
 public record ApplicationReqDto(
         @NotBlank

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
@@ -13,9 +13,6 @@ import java.util.Optional;
 
 /**
  * application을 위한 repository 입니다
- *
- * @author 변찬우
- * @since 1.0.0
  */
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
     Optional<Application> findByUserId(Long userId);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationService.java
@@ -5,9 +5,6 @@ import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReq
 
 /**
  * 원서 생성을 위한 service 입니다
- *
- * @author 변찬우
- * @since 1.0.0
  */
 public interface CreateApplicationService {
     void execute(ApplicationReqDto body, Long userId);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/data/GeneralScoreData.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/data/GeneralScoreData.java
@@ -7,9 +7,6 @@ import java.util.List;
 
 /**
  * 학기별 성적을 저장하는 record 입니다
- *
- * @author 변찬우
- * @since 1.0.0
  */
 public record GeneralScoreData(
         // 국어, 도덕, 사회, 역사, 수학, 과학, 기가, 영어, ...

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CreateApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CreateApplicationServiceImpl.java
@@ -17,9 +17,6 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 /**
  * 원서 생성을 위한 service interface 입니다
- *
- * @author 변찬우
- * @since 1.0.0
  */
 @Service
 @RequiredArgsConstructor

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/IdentityRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/IdentityRepository.java
@@ -7,9 +7,6 @@ import java.util.Optional;
 
 /**
  * Identity Entity의 JpaRepository입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 public interface IdentityRepository extends JpaRepository<Identity, Long> {
     Optional<Identity> findByUserId(Long userId);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CreateIdentityService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/CreateIdentityService.java
@@ -5,9 +5,6 @@ import team.themoment.hellogsm.web.domain.identity.dto.response.CreateIdentityRe
 
 /**
  * identityReqDto와 userId를 받아 Identity를 생성하는 인터페이스입니다.
- *
- *  * @author 양시준
- *  * @since 1.0.0
  */
 public interface CreateIdentityService {
     CreateIdentityResDto execute(IdentityReqDto reqDto, Long userId);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/IdentityQuery.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/IdentityQuery.java
@@ -4,9 +4,6 @@ import team.themoment.hellogsm.web.domain.identity.dto.domain.IdentityDto;
 
 /**
  * 주어진 userId에 해당하는 Identity를 조회하는 인터페이스입니다.
- *
- *  * @author 양시준
- *  * @since 1.0.0
  */
 public interface IdentityQuery {
     IdentityDto execute(Long userId);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/ModifyIdentityService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/ModifyIdentityService.java
@@ -5,9 +5,6 @@ import team.themoment.hellogsm.web.domain.identity.dto.request.IdentityReqDto;
 
 /**
  * identityReqDto와 userId를 받아 Identity를 생성하는 인터페이스입니다.
- *
- *  * @author 양시준
- *  * @since 1.0.0
  */
 public interface ModifyIdentityService {
     IdentityDto execute(IdentityReqDto reqDto, Long userId);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/AuthenticateCodeServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/AuthenticateCodeServiceImpl.java
@@ -16,9 +16,6 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 /**
  * CreateIdentityService의 기본 구현체입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 @Service
 @RequiredArgsConstructor

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
@@ -25,9 +25,6 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 /**
  * CreateIdentityService의 기본 구현체입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 @Service
 @RequiredArgsConstructor

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/IdentityQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/IdentityQueryImpl.java
@@ -12,9 +12,6 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 /**
  * IdentityQuery의 기본 구현체입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 @Service
 @RequiredArgsConstructor

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/exception/GlobalExceptionHandler.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/exception/GlobalExceptionHandler.java
@@ -20,9 +20,6 @@ import java.util.Map;
 
 /**
  * Global한 예외를 핸들링 하는 Handler입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 @Slf4j
 @EnableWebMvc

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/exception/error/ExpectedException.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/exception/error/ExpectedException.java
@@ -20,9 +20,6 @@ import org.springframework.http.HttpStatus;
  *  </pre>
  *
  *  @see HttpStatus
- *
- *  @author 양시준
- *  @since 1.0.0
  */
 public class ExpectedException extends RuntimeException {
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/exception/model/ExceptionResponseEntity.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/exception/model/ExceptionResponseEntity.java
@@ -2,9 +2,6 @@ package team.themoment.hellogsm.web.global.exception.model;
 
 /**
  *  Exception 발생 시 클라이언트에 반환할 Response 객체입니다
- *
- *  @author 양시준
- *  @since 1.0.0
  */
 public record ExceptionResponseEntity(String message) {
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -30,10 +30,7 @@ import java.util.Arrays;
 /**
  * SecurityConfig <br>
  * Spring Security를 위한 설정 클래스입니다. <br>
- * inner class로 프로필별 설정을 관리합니다. - 아직 예정임
- *
- * @author 양시준
- * @since 1.0.0
+ * inner class로 프로필별 설정을 관리합니다.
  */
 @Configuration
 @RequiredArgsConstructor

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthEnvironment.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthEnvironment.java
@@ -7,9 +7,6 @@ import java.util.List;
 
 /**
  * 일정 환경 설정 정보를 관리하기 위한 클래스입니다.
- *
- * @author 양시준
- * @since 1.0.0
  */
 
 @ConfigurationProperties(prefix = "auth")


### PR DESCRIPTION
## 개요

Web 모듈 객체의 Javadoc에서 `@author`, `@since` 태그를 삭제하였습니다.

## 본문

삭제 이유는 #200 과 동일합니다.
