### PR TITLE
applicaiton 리스트 조회 시 page 정보 반환하도록 변경

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationListInfoDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/response/ApplicationListInfoDto.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.dto.response;
 
 public record ApplicationListInfoDto (
-        Integer count
+        Integer totalPages,
+        Long totalElements
 ) {}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -134,10 +134,10 @@ public interface ApplicationMapper {
 
     List<TicketResDto> applicationListToTicketResDtos(List<Application> applicationList);
 
-    default ApplicationListDto createApplicationListDto(List<Application> applicationList) {
+    default ApplicationListDto createApplicationListDto(List<Application> applications) {
         return new ApplicationListDto(
-                new ApplicationListInfoDto(applicationList.size()),
-                applicationListToApplicationsDtoList(applicationList)
+                new ApplicationListInfoDto(applications.size()),
+                applicationListToApplicationsDtoList(applications)
         );
     }
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -3,6 +3,7 @@ package team.themoment.hellogsm.web.domain.application.mapper;
 import io.micrometer.common.lang.Nullable;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
+import org.springframework.data.domain.Page;
 import team.themoment.hellogsm.entity.common.util.OptionalUtils;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
 import team.themoment.hellogsm.entity.domain.application.entity.admission.AdmissionInfo;
@@ -134,9 +135,9 @@ public interface ApplicationMapper {
 
     List<TicketResDto> applicationListToTicketResDtos(List<Application> applicationList);
 
-    default ApplicationListDto createApplicationListDto(List<Application> applications) {
+    default ApplicationListDto createApplicationListDto(Page<Application> applications) {
         return new ApplicationListDto(
-                new ApplicationListInfoDto(applications.size()),
+                new ApplicationListInfoDto(applications.toList().size()),
                 applicationListToApplicationsDtoList(applications)
         );
     }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -137,8 +137,8 @@ public interface ApplicationMapper {
 
     default ApplicationListDto createApplicationListDto(Page<Application> applications) {
         return new ApplicationListDto(
-                new ApplicationListInfoDto(applications.toList().size()),
-                applicationListToApplicationsDtoList(applications)
+                new ApplicationListInfoDto(applications.getTotalPages(), applications.getTotalElements()),
+                applicationListToApplicationsDtoList(applications.toList())
         );
     }
 
@@ -303,10 +303,10 @@ public interface ApplicationMapper {
 
     List<SearchApplicationResDto> applicationsToSearchApplicationResDtos(List<Application> applications);
 
-    default SearchApplicationsResDto applicationsToSearchApplicationsResDto(List<Application> applications) {
+    default SearchApplicationsResDto applicationsToSearchApplicationsResDto(Page<Application> applications) {
         return new SearchApplicationsResDto(
-                new ApplicationListInfoDto(applications.size()),
-                applicationsToSearchApplicationResDtos(applications)
+                new ApplicationListInfoDto(applications.getTotalPages(), applications.getTotalElements()),
+                applicationsToSearchApplicationResDtos(applications.getContent())
         );
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ApplicationListQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ApplicationListQueryImpl.java
@@ -21,6 +21,6 @@ public class ApplicationListQueryImpl implements ApplicationListQuery {
     public ApplicationListDto execute(Integer page, Integer size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
         Page<Application> applicationPage = applicationRepository.findAll(pageable);
-        return ApplicationMapper.INSTANCE.createApplicationListDto(applicationPage.getContent());
+        return ApplicationMapper.INSTANCE.createApplicationListDto(applicationPage);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/SearchApplicationsServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/SearchApplicationsServiceImpl.java
@@ -22,7 +22,7 @@ public class SearchApplicationsServiceImpl implements SearchApplicationsService 
     @Override
     public SearchApplicationsResDto execute(Integer page, Integer size, @Nullable SearchTag tag, @Nullable String keyword) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
-        return ApplicationMapper.INSTANCE.applicationsToSearchApplicationsResDto(applicationPage(tag, keyword, pageable).getContent());
+        return ApplicationMapper.INSTANCE.applicationsToSearchApplicationsResDto(applicationPage(tag, keyword, pageable));
     }
 
     public Page<Application> applicationPage(SearchTag tag, String keyword, Pageable pageable) {

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -476,7 +476,7 @@ class ApplicationControllerTest {
     @DisplayName("원서 전체 조회")
     void findAll() throws Exception {
         ApplicationListDto applicationListDto = new ApplicationListDto(
-                new ApplicationListInfoDto(1),
+                new ApplicationListInfoDto(1, 1L),
                 List.of(new ApplicationsDto(
                         1L,
                         "human",
@@ -505,7 +505,8 @@ class ApplicationControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.info.count").value(applicationListDto.info().count()))
+                .andExpect(jsonPath("$.info.totalPages").value(applicationListDto.info().totalPages()))
+                .andExpect(jsonPath("$.info.totalElements").value(applicationListDto.info().totalElements()))
                 .andExpect(jsonPath("$.applications[0].applicationId").value(applicationListDto.applications().get(0).applicationId()))
                 .andExpect(jsonPath("$.applications[0].applicantName").value(applicationListDto.applications().get(0).applicantName()))
                 .andExpect(jsonPath("$.applications[0].graduation").value(applicationListDto.applications().get(0).graduation().toString()))
@@ -526,7 +527,8 @@ class ApplicationControllerTest {
                         ),
                         requestSessionCookie(),
                         responseFields(
-                                fieldWithPath("info.count").type(NUMBER).description("원서 개수"),
+                                fieldWithPath("info.totalPages").type(NUMBER).description("총 페이지 개수"),
+                                fieldWithPath("info.totalElements").type(NUMBER).description("모든 원서 개수"),
                                 fieldWithPath("applications[].applicationId").type(NUMBER).description("원서 식별자"),
                                 fieldWithPath("applications[].applicantName").type(STRING).description("지원자 이름"),
                                 fieldWithPath("applications[].graduation").type(STRING).description("중학교 졸업 상태"),
@@ -550,7 +552,7 @@ class ApplicationControllerTest {
     @DisplayName("원서 리스트 검색")
     void search() throws Exception {
         SearchApplicationsResDto searchApplicationsResDto = new SearchApplicationsResDto(
-                new ApplicationListInfoDto(1),
+                new ApplicationListInfoDto(1,1L),
                 List.of(new SearchApplicationResDto(
                         1L,
                         true,
@@ -578,7 +580,8 @@ class ApplicationControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.info.count").value(searchApplicationsResDto.info().count()))
+                .andExpect(jsonPath("$.info.totalPages").value(searchApplicationsResDto.info().totalPages()))
+                .andExpect(jsonPath("$.info.totalElements").value(searchApplicationsResDto.info().totalElements()))
                 .andExpect(jsonPath("$.applications[0].applicationId").value(searchApplicationsResDto.applications().get(0).applicationId()))
                 .andExpect(jsonPath("$.applications[0].applicantName").value(searchApplicationsResDto.applications().get(0).applicantName()))
                 .andExpect(jsonPath("$.applications[0].isFinalSubmitted").value(searchApplicationsResDto.applications().get(0).isFinalSubmitted()))
@@ -600,7 +603,8 @@ class ApplicationControllerTest {
                         ),
                         requestSessionCookie(),
                         responseFields(
-                                fieldWithPath("info.count").type(NUMBER).description("원서 개수"),
+                                fieldWithPath("info.totalPages").type(NUMBER).description("총 페이지 개수"),
+                                fieldWithPath("info.totalElements").type(NUMBER).description("모든 원서 개수"),
                                 fieldWithPath("applications[].applicationId").type(NUMBER).description("원서 식별자"),
                                 fieldWithPath("applications[].isFinalSubmitted").type(BOOLEAN).description("최종 제출 여부"),
                                 fieldWithPath("applications[].isPrintsArrived").type(BOOLEAN).description("서류 도착 여부"),


### PR DESCRIPTION
## 개요

applicaiton 리스트 조회/검색 시에 page 정보를 반환하도록 변경하였습니다.

## 본문

### 변경

- `ApplicationListInfoDto` : 총 요소의 개수, 페이지의 개수를 필드로 가지도록 변경
- `ApplicationMapper` 
  - 페이지네이션 정보를 포함하기 위해 일부 메서드 파라미터 타입을 List에서 Page로 변경
  - Page의 메서드를 사용해서 페이지네이션 관련 정보를 가져옴
- `ApplicationMapper` 변경으로 인한 `ApplicationListQueryImpl`, `SearchApplicationsServiceImpl` 수정
- `ApplicationControllerTest` : 테스트코드 수정
