### PR TITLE
어플리케이션 로그를 cloudwatch logs로 전송하는 기능 구현

### DIFF
--- a/hellogsm-web/build.gradle
+++ b/hellogsm-web/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     /** aws **/
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.1'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sns:3.0.1'
+    implementation 'ca.pjer:logback-awslogs-appender:1.6.0'
 }
 
 task restDocsTest(type: Test) {

--- a/hellogsm-web/src/main/resources/logback-spring.xml
+++ b/hellogsm-web/src/main/resources/logback-spring.xml
@@ -1,56 +1,83 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <configuration scan="true" scanPeriod="30 seconds">
-  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-  <!--로그 파일 저장 위치-->
-  <property name="LOG_PATH" value="./logs"/>
-  <property name="LOG_NAME" value="hellolog"/>
+    <!--Spring 환경변수 불러오기-->
+    <springProperty name="AWS_ACCESS_KEY" source="spring.cloud.aws.credentials.access-key"/>
+    <springProperty name="AWS_SECRET_KEY" source="spring.cloud.aws.credentials.secret-key"/>
 
-  <springProfile name = "local | dev | prod" >
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-      <encoder>
-        <pattern>${CONSOLE_LOG_PATTERN}</pattern>
-        <charset>${CONSOLE_LOG_CHARSET}</charset>
-      </encoder>
-    </appender>
+    <!--로그 파일 저장 위치-->
+    <property name="LOG_PATH" value="./logs"/>
+    <property name="LOG_NAME" value="hellolog"/>
 
-    <logger name="org.springframework" level="INFO">
-      <appender-ref ref="CONSOLE" />
-    </logger>
-    <logger name="org.hibernate.orm.jdbc.bind" level="trace">
-      <appender-ref ref="CONSOLE"/>
-    </logger>
-    <logger name="team.themoment.hellogsm">
-      <appender-ref ref="CONSOLE"/>
-    </logger>
-  </springProfile>
+    <!--로그 콘솔 출력-->
+    <springProfile name="local | dev | prod">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+                <charset>${CONSOLE_LOG_CHARSET}</charset>
+            </encoder>
+        </appender>
 
-  <springProfile name = "dev | prod" >
-    <appender name="ROLLING-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-      <file>${LOG_PATH}/${LOG_NAME}.log</file>
-      <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-        <pattern>${FILE_LOG_PATTERN}</pattern>
-        <charset>${FILE_LOG_CHARSET}</charset>
-      </encoder>
-      <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-        <fileNamePattern>${LOG_PATH}/${LOG_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-        <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-          <maxFileSize>10MB</maxFileSize>
-        </timeBasedFileNamingAndTriggeringPolicy>
-        <maxHistory>365</maxHistory>
-        <totalSizeCap>10GB</totalSizeCap>
-      </rollingPolicy>
-    </appender>
+        <logger name="org.springframework" level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+        <logger name="org.hibernate.orm.jdbc.bind" level="TRACE">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+        <logger name="team.themoment.hellogsm" level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </logger>
+    </springProfile>
 
-    <logger name="org.springframework" level="INFO">
-      <appender-ref ref="ROLLING-FILE"/>
-    </logger>
-    <logger name="org.hibernate.orm.jdbc.bind" level="trace">
-      <appender-ref ref="ROLLING-FILE"/>
-    </logger>
-    <logger name="team.themoment.hellogsm" level="trace">
-      <appender-ref ref="ROLLING-FILE"/>
-    </logger>
-  </springProfile>
+    <springProfile name="dev | prod">
+
+        <!--로그 파일 저장-->
+        <appender name="ROLLING-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/${LOG_NAME}.log</file>
+            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+                <charset>${FILE_LOG_CHARSET}</charset>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/${LOG_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                    <maxFileSize>10MB</maxFileSize>
+                </timeBasedFileNamingAndTriggeringPolicy>
+                <maxHistory>365</maxHistory>
+                <totalSizeCap>10GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <!--로그 AWS CloudWatch로 등록-->
+        <appender name="CLOUD-WATCH" class="ca.pjer.logback.AwsLogsAppender">
+            <layout>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %X{AWS-XRAY-TRACE-ID} %level [%thread] %logger{35} : %msg%n
+                </pattern>
+            </layout>
+            <logGroupName>hello-dev-test</logGroupName>
+            <logStreamUuidPrefix>hello-log-</logStreamUuidPrefix>
+            <logRegion>ap-northeast-2</logRegion>
+            <maxBatchLogEvents>50</maxBatchLogEvents>
+            <maxFlushTimeMillis>30000</maxFlushTimeMillis>
+            <maxBlockTimeMillis>5000</maxBlockTimeMillis>
+            <retentionTimeDays>0</retentionTimeDays>
+            <accessKeyId>${AWS_ACCESS_KEY}</accessKeyId>
+            <secretAccessKey>${AWS_SECRET_KEY}</secretAccessKey>
+        </appender>
+
+        <logger name="org.springframework" level="INFO">
+            <appender-ref ref="ROLLING-FILE"/>
+            <appender-ref ref="CLOUD-WATCH"/>
+        </logger>
+        <logger name="org.hibernate.orm.jdbc.bind" level="trace">
+            <appender-ref ref="ROLLING-FILE"/>
+            <appender-ref ref="CLOUD-WATCH"/>
+        </logger>
+        <logger name="team.themoment.hellogsm" level="trace">
+            <appender-ref ref="ROLLING-FILE"/>
+            <appender-ref ref="CLOUD-WATCH"/>
+        </logger>
+    </springProfile>
 </configuration>


### PR DESCRIPTION
## 개요

어플리케이션 로그를 cloudwatch logs로 전송하는 기능을 구현하였습니다.

## 본문

prod 환경 설정은 아직 되어있지 않습니다. 추후에 추가하도록 하겠습니다.

### 추가

- `logback-spring.xml` : cloudwatch logs appender 설정 추가
- `build.gradle` : `ca.pjer:logback-awslogs-appender` 의존성 추가