### PR TITLE
AWS X-ray 구성 추가

### DIFF
--- a/hellogsm-web/build.gradle
+++ b/hellogsm-web/build.gradle
@@ -19,6 +19,12 @@ configurations {
     asciidoctorExt
 }
 
+dependencyManagement {
+    imports {
+        mavenBom ('com.amazonaws:aws-xray-recorder-sdk-bom:2.14.0')
+    }
+}
+
 dependencies {
     /** entity **/
     implementation project(':hellogsm-entity')
@@ -54,7 +60,7 @@ dependencies {
     /** aws **/
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.1'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sns:3.0.1'
-    implementation 'com.amazonaws:aws-xray-recorder-sdk-spring:2.14.0'
+    implementation 'com.amazonaws:aws-xray-recorder-sdk-spring'
 }
 
 task restDocsTest(type: Test) {

--- a/hellogsm-web/build.gradle
+++ b/hellogsm-web/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     /** aws **/
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.1'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sns:3.0.1'
+    implementation 'com.amazonaws:aws-xray-recorder-sdk-spring:2.14.0'
 }
 
 task restDocsTest(type: Test) {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ApplicationListQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ApplicationListQueryImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -13,6 +14,7 @@ import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepo
 import team.themoment.hellogsm.web.domain.application.service.ApplicationListQuery;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class ApplicationListQueryImpl implements ApplicationListQuery {
     final ApplicationRepository applicationRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CascadeDeleteApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CascadeDeleteApplicationServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,7 @@ import java.util.Optional;
 
 @Slf4j
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class CascadeDeleteApplicationServiceImpl implements CascadeDeleteApplicationService {
     private final ApplicationRepository applicationRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CreateApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/CreateApplicationServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
  * 원서 생성을 위한 service interface 입니다
  */
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class CreateApplicationServiceImpl implements CreateApplicationService {
     private final UserRepository userRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DeleteApplicationServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import team.themoment.hellogsm.web.domain.application.service.DeleteApplicationS
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 @Transactional(rollbackFor = {Exception.class})
 public class DeleteApplicationServiceImpl implements DeleteApplicationService {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/FinalSubmissionServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/FinalSubmissionServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,7 @@ import team.themoment.hellogsm.web.domain.application.service.FinalSubmissionSer
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class FinalSubmissionServiceImpl implements FinalSubmissionService {
     private final ApplicationRepository applicationRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationForConsistencyImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationForConsistencyImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
@@ -12,6 +13,7 @@ import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationF
 import java.util.Optional;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class ModifyApplicationForConsistencyImpl implements ModifyApplicationForConsistency {
     private final ApplicationRepository applicationRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class ModifyApplicationServiceImpl implements ModifyApplicationService {
     private final UserRepository userRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationStatusServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationStatusServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationS
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class ModifyApplicationStatusServiceImpl implements ModifyApplicationStatusService {
     final private ApplicationRepository applicationRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/QuerySingleApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/QuerySingleApplicationServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,7 @@ import team.themoment.hellogsm.web.domain.application.service.QuerySingleApplica
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class QuerySingleApplicationServiceImpl implements QuerySingleApplicationService {
     final private ApplicationRepository applicationRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/QueryTicketsServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/QueryTicketsServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
@@ -12,6 +13,7 @@ import team.themoment.hellogsm.web.domain.application.service.QueryTicketsServic
 import java.util.List;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class QueryTicketsServiceImpl implements QueryTicketsService {
     final private ApplicationRepository applicationRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/SearchApplicationsServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/SearchApplicationsServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,6 +16,7 @@ import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepo
 import team.themoment.hellogsm.web.domain.application.service.SearchApplicationsService;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class SearchApplicationsServiceImpl implements SearchApplicationsService {
     final ApplicationRepository applicationRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/AuthenticateCodeServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/AuthenticateCodeServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.identity.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
  * CreateIdentityService의 기본 구현체입니다.
  */
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 @Transactional(rollbackFor = {Exception.class})
 public class AuthenticateCodeServiceImpl implements AuthenticateCodeService {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CascadeDeleteIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CascadeDeleteIdentityServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.identity.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,7 @@ import java.util.Optional;
 
 @Slf4j
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class CascadeDeleteIdentityServiceImpl implements CascadeDeleteIdentityService {
     private final IdentityRepository identityRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/CreateIdentityServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.identity.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpStatus;
@@ -27,6 +28,7 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
  * CreateIdentityService의 기본 구현체입니다.
  */
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 @Transactional(rollbackFor = {Exception.class})
 public class CreateIdentityServiceImpl implements CreateIdentityService {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/GenerateCodeServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/GenerateCodeServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.identity.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,7 @@ import team.themoment.hellogsm.web.domain.identity.service.GenerateCodeService;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class GenerateCodeServiceImpl implements GenerateCodeService {
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/GenerateTestCodeServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/GenerateTestCodeServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.identity.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.Random;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class GenerateTestCodeServiceImpl implements GenerateTestCodeService {
     private final static Random RANDOM = new Random();

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/IdentityQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/IdentityQueryImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.identity.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
  * IdentityQuery의 기본 구현체입니다.
  */
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class IdentityQueryImpl implements IdentityQuery {
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/ModifyIdentityServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/service/impl/ModifyIdentityServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.identity.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,7 @@ import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 @Transactional(rollbackFor = {Exception.class})
 public class ModifyIdentityServiceImpl implements ModifyIdentityService {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/CreateUserServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/CreateUserServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.user.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,7 @@ import team.themoment.hellogsm.web.domain.user.service.CreateUserService;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 @Transactional(rollbackFor = {Exception.class})
 public class CreateUserServiceImpl implements CreateUserService {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/DeleteUserServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/DeleteUserServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.user.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import team.themoment.hellogsm.web.domain.user.service.DeleteUserService;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 @Transactional(rollbackFor = {Exception.class})
 public class DeleteUserServiceImpl implements DeleteUserService {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/ExistUserQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/ExistUserQueryImpl.java
@@ -1,11 +1,13 @@
 package team.themoment.hellogsm.web.domain.user.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
 import team.themoment.hellogsm.web.domain.user.service.ExistUserQuery;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class ExistUserQueryImpl implements ExistUserQuery {
     private final UserRepository userRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/UserByIdQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/UserByIdQueryImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.user.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,7 @@ import team.themoment.hellogsm.web.domain.user.service.UserByIdQuery;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class UserByIdQueryImpl implements UserByIdQuery {
     private final UserRepository userRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/UserByProviderQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/UserByProviderQueryImpl.java
@@ -11,6 +11,7 @@ import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
 import team.themoment.hellogsm.web.domain.user.service.UserByProviderQuery;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
+@Service
 @XRayEnabled
 @RequiredArgsConstructor
 public class UserByProviderQueryImpl implements UserByProviderQuery {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/UserByProviderQueryImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/service/impl/UserByProviderQueryImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.user.service.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -10,7 +11,7 @@ import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
 import team.themoment.hellogsm.web.domain.user.service.UserByProviderQuery;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
-@Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class UserByProviderQueryImpl implements UserByProviderQuery {
     private final UserRepository userRepository;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/oauth/CustomOauth2UserService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/oauth/CustomOauth2UserService.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.global.security.oauth;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import team.themoment.hellogsm.entity.domain.user.entity.User;
@@ -18,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 
 @Service
+@XRayEnabled
 public class CustomOauth2UserService implements OAuth2UserService {
 
     private final OAuth2UserService<OAuth2UserRequest, OAuth2User> delegateOauth2UserService;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/application/impl/ImageSaveServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/application/impl/ImageSaveServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.global.thirdParty.aws.service.application.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,7 @@ import team.themoment.hellogsm.web.global.thirdParty.aws.service.aws.ImageUpload
 import java.util.Objects;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class ImageSaveServiceImpl implements ImageSaveService {
     private final ImageUploadService imageUploadService;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/ImageUploadServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/ImageUploadServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.global.thirdParty.aws.service.aws.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import io.awspring.cloud.s3.S3Resource;
 import io.awspring.cloud.s3.S3Template;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 public class ImageUploadServiceImpl implements ImageUploadService {
     private final S3Template s3Template;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/SendSmsServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/SendSmsServiceImpl.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.global.thirdParty.aws.service.aws.impl;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import io.awspring.cloud.sns.sms.SmsMessageAttributes;
 import io.awspring.cloud.sns.sms.SmsType;
 import io.awspring.cloud.sns.sms.SnsSmsTemplate;
@@ -10,6 +11,7 @@ import team.themoment.hellogsm.web.global.thirdParty.aws.service.aws.SendSmsServ
 import team.themoment.hellogsm.web.global.thirdParty.aws.service.template.AwsTemplate;
 
 @Service
+@XRayEnabled
 @RequiredArgsConstructor
 @Slf4j
 public class SendSmsServiceImpl implements SendSmsService {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/xray/XRayInspector.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/xray/XRayInspector.java
@@ -1,0 +1,24 @@
+package team.themoment.hellogsm.web.global.thirdParty.aws.xray;
+
+import com.amazonaws.xray.entities.Subsegment;
+import com.amazonaws.xray.spring.aop.BaseAbstractXRayInterceptor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Aspect
+@Component
+public class XRayInspector extends BaseAbstractXRayInterceptor {
+    @Override
+    protected Map<String, Map<String, Object>> generateMetadata(ProceedingJoinPoint proceedingJoinPoint, Subsegment subsegment) {
+        return super.generateMetadata(proceedingJoinPoint, subsegment);
+    }
+
+    @Override
+    @Pointcut("@within(com.amazonaws.xray.spring.aop.XRayEnabled) && bean(*Controller)")
+    public void xrayEnabledClasses() {}
+
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/xray/XRayInspector.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/xray/XRayInspector.java
@@ -1,7 +1,7 @@
 package team.themoment.hellogsm.web.global.thirdParty.aws.xray;
 
 import com.amazonaws.xray.entities.Subsegment;
-import com.amazonaws.xray.spring.aop.BaseAbstractXRayInterceptor;
+import com.amazonaws.xray.spring.aop.AbstractXRayInterceptor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
@@ -11,7 +11,7 @@ import java.util.Map;
 
 @Aspect
 @Component
-public class XRayInspector extends BaseAbstractXRayInterceptor {
+public class XRayInspector extends AbstractXRayInterceptor {
     @Override
     protected Map<String, Map<String, Object>> generateMetadata(ProceedingJoinPoint proceedingJoinPoint, Subsegment subsegment) {
         return super.generateMetadata(proceedingJoinPoint, subsegment);
@@ -19,6 +19,7 @@ public class XRayInspector extends BaseAbstractXRayInterceptor {
 
     @Override
     @Pointcut("@within(com.amazonaws.xray.spring.aop.XRayEnabled) && bean(*Controller)")
-    public void xrayEnabledClasses() {}
+    public void xrayEnabledClasses() {
+    }
 
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/xray/config/AWSXRayConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/xray/config/AWSXRayConfig.java
@@ -1,0 +1,14 @@
+package team.themoment.hellogsm.web.global.thirdParty.aws.xray.config;
+
+import com.amazonaws.xray.jakarta.servlet.AWSXRayServletFilter;
+import com.amazonaws.xray.strategy.jakarta.SegmentNamingStrategy;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Bean;
+
+@Configuration
+public class AWSXRayConfig {
+    @Bean
+    public AWSXRayServletFilter TracingFilter() {
+        return new AWSXRayServletFilter(SegmentNamingStrategy.dynamic("HelloGSM-Web-BE"));
+    }
+}


### PR DESCRIPTION
## 개요

어플리케이션 trace 정보를 확인할 수 있도록 AWS X-ray를 구성하였습니다.

## 본문

X-ray의 trace 기능을 cloudwatch logs에 등록되는 trace id를 사용해 분석하기 때문에
해당 작업과 #210 작업 둘 다 머지되어야 정상적으로 동작합니다.

### 추가

- `com.amazonaws:aws-xray-recorder-sdk-spring` 의존성 추가
- `AWSXRayConfig` : X-ray Config 객체 구현
- `XRayInspector` : AOP를 사용해서 비 침투적으로 x-ray를 사용

### 변경

- `@Service`를 사용하는 객체에 `@XRayEnabled` 추가

