### PR TITLE
`ModifyApplicationForConsistencyImpl`의 누락된 log 추가

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationForConsistencyImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationForConsistencyImpl.java
@@ -1,6 +1,7 @@
 package team.themoment.hellogsm.web.domain.application.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
 import team.themoment.hellogsm.entity.domain.application.entity.admission.AdmissionInfo;
@@ -11,6 +12,7 @@ import team.themoment.hellogsm.web.domain.application.service.ModifyApplicationF
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ModifyApplicationForConsistencyImpl implements ModifyApplicationForConsistency {
@@ -33,6 +35,8 @@ public class ModifyApplicationForConsistencyImpl implements ModifyApplicationFor
                             savedApplication.getMiddleSchoolGrade(),
                             savedApplication.getUserId()
                     ));
+        } else {
+            log.warn("Application이 없는 User의 Identity 수정 발생 - User Id: {}", identity.getUserId());
         }
     }
 }


### PR DESCRIPTION
## 개요

`ModifyApplicationForConsistencyImpl#execute`에서 `savedApplicationOpt` 가 존재하지 않는 경우 logging이 누락되었던 문제를 해결하였습니다.
