### PR TITLE
 X-ray 인식 못하는 문제 수정

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.repository;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +15,7 @@ import java.util.Optional;
 /**
  * application을 위한 repository 입니다
  */
+@XRayEnabled
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
     Optional<Application> findByUserId(Long userId);
     Boolean existsByUserId(Long userId);

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/CodeRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/CodeRepository.java
@@ -1,11 +1,13 @@
 package team.themoment.hellogsm.web.domain.identity.repository;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.List;
 
 import team.themoment.hellogsm.web.domain.identity.domain.AuthenticationCode;
 
+@XRayEnabled
 public interface CodeRepository extends CrudRepository<AuthenticationCode, String> {
     List<AuthenticationCode> findByUserId(Long userId);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/IdentityRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/identity/repository/IdentityRepository.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.identity.repository;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
 
@@ -8,6 +9,7 @@ import java.util.Optional;
 /**
  * Identity Entity의 JpaRepository입니다.
  */
+@XRayEnabled
 public interface IdentityRepository extends JpaRepository<Identity, Long> {
     Optional<Identity> findByUserId(Long userId);
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/repository/UserRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/user/repository/UserRepository.java
@@ -1,10 +1,12 @@
 package team.themoment.hellogsm.web.domain.user.repository;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team.themoment.hellogsm.entity.domain.user.entity.User;
 
 import java.util.Optional;
 
+@XRayEnabled
 public interface UserRepository extends JpaRepository<User, Long> {
     Boolean existsByProviderAndProviderId(String provider, String providerId);
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/xray/XRayInspector.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/xray/XRayInspector.java
@@ -18,7 +18,7 @@ public class XRayInspector extends AbstractXRayInterceptor {
     }
 
     @Override
-    @Pointcut("@within(com.amazonaws.xray.spring.aop.XRayEnabled) && bean(*Controller)")
+    @Pointcut("@within(com.amazonaws.xray.spring.aop.XRayEnabled) || bean(*Controller)")
     public void xrayEnabledClasses() {
     }
 


### PR DESCRIPTION
## 개요
 X-ray 구성이 잘못 설정된 문제 수정

## 본문

1.  Aop Pointcut 표현식 범위 잘못 설정된 문제 수정
2. `Repository` 구현체에 누락된 `@XRayEnabled` 추가

### 추가 

- `Repository`를 구현하는 객체에 `@XRayEnabled` 추가

### 변경 
 
- `XRayInspector#xrayEnabledClasses`   `@Pointcut` 범위 수정

