### PR TITLE
CloudWatch 관련 logback 설정 변경

### DIFF
--- a/hellogsm-web/build.gradle
+++ b/hellogsm-web/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.1'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sns:3.0.1'
     implementation 'com.amazonaws:aws-xray-recorder-sdk-spring'
-    implementation 'ca.pjer:logback-awslogs-appender:1.6.0'
 }
 
 task restDocsTest(type: Test) {

--- a/hellogsm-web/src/main/resources/logback-spring.xml
+++ b/hellogsm-web/src/main/resources/logback-spring.xml
@@ -8,7 +8,7 @@
     <springProperty name="AWS_SECRET_KEY" source="spring.cloud.aws.credentials.secret-key"/>
 
     <!--로그 파일 저장 위치-->
-    <property name="LOG_PATH" value="./logs"/>
+    <property name="LOG_PATH" value="/var/log/hellogsm"/>
     <property name="LOG_NAME" value="hellolog"/>
 
     <!--로그 콘솔 출력-->

--- a/hellogsm-web/src/main/resources/logback-spring.xml
+++ b/hellogsm-web/src/main/resources/logback-spring.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<configuration scan="true" scanPeriod="30 seconds">
+<configuration scan="true" scanPeriod="30 seconds"> <!-- 30초 간격으로 SCAN -->
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
     <!--Spring 환경변수 불러오기-->
@@ -8,8 +8,8 @@
     <springProperty name="AWS_SECRET_KEY" source="spring.cloud.aws.credentials.secret-key"/>
 
     <!--로그 파일 저장 위치-->
-    <property name="LOG_PATH" value="/var/log/hellogsm"/>
-    <property name="LOG_NAME" value="hellolog"/>
+    <property name="LOG_PATH" value="/var/log/hellogsm/web"/>
+    <property name="LOG_NAME" value="log"/>
 
     <!--로그 콘솔 출력-->
     <springProfile name="local | dev | prod">
@@ -31,17 +31,21 @@
         </logger>
     </springProfile>
 
+
     <springProfile name="dev | prod">
 
-        <!--로그 파일 저장-->
+        <!--로그 파일 저장, 혹시 모를 Backup 용 -->
         <appender name="ROLLING-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>${LOG_PATH}/${LOG_NAME}.log</file>
+            <file>${LOG_PATH}/backup/${LOG_NAME}.log</file>
             <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
                 <pattern>${FILE_LOG_PATTERN}</pattern>
                 <charset>${FILE_LOG_CHARSET}</charset>
             </encoder>
+            <!-- ${LOG_NAME}이 이름인 파일(<file> 로 정의한)에 작성되다가 Rolling 조건이 되면
+            파일 이름이 ${LOG_NAME}-2022-02-22.0 으로 변경되어 저장, 이후 새로운 파일 ${LOG_NAME} 파일에 로그가 작성됨 -->
+            <!-- cloudwatch 조건으로 ${LOG_NAME}이 prefix인 로그를 저장하라고 설정하기 -->
             <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>${LOG_PATH}/${LOG_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <fileNamePattern>${LOG_PATH}/backup/${LOG_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
                 <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                     <maxFileSize>10MB</maxFileSize>
                 </timeBasedFileNamingAndTriggeringPolicy>
@@ -50,33 +54,35 @@
             </rollingPolicy>
         </appender>
 
-        <!--로그 AWS CloudWatch로 등록-->
-        <appender name="CLOUD-WATCH" class="ca.pjer.logback.AwsLogsAppender">
-            <layout>
+        <!-- 로그 AWS CloudWatch Logs 에 등록하기 위한 로그 파일, 데이터가 많이 발생하면 기존 데이터를 대체함 -->
+        <!-- CloudWatch Agent 가 해당 파일을 읽고 로그를 전송함 -->
+        <appender name="FILE-FOR-CLOUD-WATCH" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/cloudwatch/${LOG_NAME}.log</file>
+            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
                 <pattern>${FILE_LOG_PATTERN}</pattern>
-            </layout>
-            <logGroupName>hello-dev-test</logGroupName>
-            <logStreamUuidPrefix>hello-log-</logStreamUuidPrefix>
-            <logRegion>ap-northeast-2</logRegion>
-            <maxBatchLogEvents>50</maxBatchLogEvents>
-            <maxFlushTimeMillis>30000</maxFlushTimeMillis>
-            <maxBlockTimeMillis>5000</maxBlockTimeMillis>
-            <retentionTimeDays>0</retentionTimeDays>
-            <accessKeyId>${AWS_ACCESS_KEY}</accessKeyId>
-            <secretAccessKey>${AWS_SECRET_KEY}</secretAccessKey>
+                <charset>${FILE_LOG_CHARSET}</charset>
+            </encoder>
+            <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+                <maxFileSize>10MB</maxFileSize> <!-- 각 파일의 최대 크기 -->
+            </triggeringPolicy>
+            <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/cloudwatch/${LOG_NAME}.%i.log</fileNamePattern>
+                <minIndex>1</minIndex>
+                <maxIndex>10</maxIndex> <!-- 최대 파일 수 (10개로 설정) -->
+            </rollingPolicy>
         </appender>
 
         <logger name="org.springframework" level="INFO">
             <appender-ref ref="ROLLING-FILE"/>
-            <appender-ref ref="CLOUD-WATCH"/>
+            <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
         </logger>
         <logger name="org.hibernate.orm.jdbc.bind" level="trace">
             <appender-ref ref="ROLLING-FILE"/>
-            <appender-ref ref="CLOUD-WATCH"/>
+            <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
         </logger>
         <logger name="team.themoment.hellogsm" level="trace">
             <appender-ref ref="ROLLING-FILE"/>
-            <appender-ref ref="CLOUD-WATCH"/>
+            <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
         </logger>
     </springProfile>
 </configuration>

--- a/hellogsm-web/src/main/resources/logback-spring.xml
+++ b/hellogsm-web/src/main/resources/logback-spring.xml
@@ -2,11 +2,7 @@
 
 <configuration scan="true" scanPeriod="30 seconds"> <!-- 30초 간격으로 SCAN -->
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-
-    <!--Spring 환경변수 불러오기-->
-    <springProperty name="AWS_ACCESS_KEY" source="spring.cloud.aws.credentials.access-key"/>
-    <springProperty name="AWS_SECRET_KEY" source="spring.cloud.aws.credentials.secret-key"/>
-
+    
     <!--로그 파일 저장 위치-->
     <property name="LOG_PATH" value="/var/log/hellogsm/web"/>
     <property name="LOG_NAME" value="log"/>

--- a/hellogsm-web/src/main/resources/logback-spring.xml
+++ b/hellogsm-web/src/main/resources/logback-spring.xml
@@ -53,8 +53,7 @@
         <!--로그 AWS CloudWatch로 등록-->
         <appender name="CLOUD-WATCH" class="ca.pjer.logback.AwsLogsAppender">
             <layout>
-                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %X{AWS-XRAY-TRACE-ID} %level [%thread] %logger{35} : %msg%n
-                </pattern>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
             </layout>
             <logGroupName>hello-dev-test</logGroupName>
             <logStreamUuidPrefix>hello-log-</logStreamUuidPrefix>


### PR DESCRIPTION
## 개요

`ca.pjer.logback.AwsLogsAppender` 대신 파일로 작성한 로그를 작성하고,
CloudWatch Agent가 CloudWatch Logs에 전송할 수 있도록 변경였습니다.

## 본문

`ca.pjer.logback.AwsLogsAppender` 라이브러리가 2년째 업데이트가 없기도 하고, 
관련된 기능을 커스텀하기 어려울 수 있다고 생각해서 AWS에서 제공하는 CloudWatch Agent를 사용하도록 변경하였습니다.

### 추가 

- 파일 로그 추가 (`RollingFileAppender`)
  - cloudwatch에 저장하기 위한 log를 따로 추가하였습니다.
  - 일정 데이터 이상 쌓이지 않도록 rotation 되게 설정하였습니다.

### 변경

- `AwsLogsAppender` 관련 의존성, 설정 삭제
- cloudwatch용 로그와 backup용 로그를 분리하기 위해서 디렉토리 위치 변경

### 기타
브랜치 삭제하고 다시 만드는걸 까먹어서 이전 브랜치 작업까지 함께 수정된 걸로 나오네요...
감안하면서 봐주시면 감사하겠습니다.