### PR TITLE
CreateApplicationServiceImpl 단위테스트 작성

### DIFF
--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -99,4 +99,19 @@ public class CreateApplicationServiceImplTest {
 
         assertEquals(expectedMessage, exception.getMessage());
     }
+
+    @Test
+    public void 이미_존재하는_Application() {
+        // given
+        given(userRepository.existsById(any(Long.class))).willReturn(true);
+        given(applicationRepository.existsByUserId(any(Long.class))).willReturn(true);
+
+        // when & then
+        ExpectedException exception = assertThrows(ExpectedException.class, () ->
+                createApplicationService.execute(applicationReqDto, 1L));
+
+        String expectedMessage = "원서가 이미 존재합니다";
+
+        assertEquals(expectedMessage, exception.getMessage());
+    }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -1,0 +1,87 @@
+package team.themoment.hellogsm.web.domain.application.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.hellogsm.entity.domain.application.entity.Application;
+import team.themoment.hellogsm.entity.domain.application.enums.Gender;
+import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
+import team.themoment.hellogsm.web.domain.application.service.impl.CreateApplicationServiceImpl;
+import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
+import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class CreateApplicationServiceImplTest {
+
+    @InjectMocks
+    private CreateApplicationServiceImpl createApplicationService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private IdentityRepository identityRepository;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    private final ApplicationReqDto applicationReqDto = new ApplicationReqDto(
+            "https://naver.com",
+            "지원자 집주소",
+            "지원자 상세주소",
+            "GED",
+            "01012341234",
+            "홍길동",
+            "부",
+            "01044447777",
+            "김철수",
+            "01077774444",
+            "SW",
+            "AI",
+            "IOT",
+            "{\"curriculumScoreSubtotal\":100,\"nonCurriculumScoreSubtotal\":100,\"rankPercentage\":0,\"scoreTotal\":261}",
+            "지원자 학교 이름",
+            "지원자 학교 위치",
+           "GENERAL"
+    );
+
+    private final Identity identity = new Identity(
+            1L,
+            "차무식",
+            "01012345678",
+            LocalDate.EPOCH,
+            Gender.MALE,
+            1L
+    );
+
+    private void givenIdentity() {
+        given(identityRepository.findByUserId(any(Long.class))).willReturn(Optional.of(identity));
+    }
+
+    private void verifyExistence() {
+        given(applicationRepository.existsByUserId(any(Long.class))).willReturn(false);
+        given(userRepository.existsById(any(Long.class))).willReturn(true);
+    }
+
+    @Test
+    public void 성공() {
+        // given
+        givenIdentity();
+        verifyExistence();
+
+        // when & then
+        assertDoesNotThrow(() -> createApplicationService.execute(applicationReqDto, 1L));
+    }
+}

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -114,4 +114,19 @@ public class CreateApplicationServiceImplTest {
 
         assertEquals(expectedMessage, exception.getMessage());
     }
+
+    @Test
+    public void 존재하지_않는_Identity() {
+        //given
+        verifyExistence();
+        given(identityRepository.findByUserId(any(Long.class))).willReturn(Optional.empty());
+
+        // when & then
+        ExpectedException exception = assertThrows(ExpectedException.class, () ->
+                createApplicationService.execute(applicationReqDto, 1L));
+
+        String expectedMessage = "Identity가 존재하지 않습니다";
+
+        assertEquals(expectedMessage, exception.getMessage());
+    }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -14,11 +14,12 @@ import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepo
 import team.themoment.hellogsm.web.domain.application.service.impl.CreateApplicationServiceImpl;
 import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
 import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
+import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 import java.time.LocalDate;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -83,5 +84,19 @@ public class CreateApplicationServiceImplTest {
 
         // when & then
         assertDoesNotThrow(() -> createApplicationService.execute(applicationReqDto, 1L));
+    }
+
+    @Test
+    public void 존재하지_않는_User() {
+        // given
+        given(userRepository.existsById(any(Long.class))).willReturn(false);
+
+        // when & then
+        ExpectedException exception = assertThrows(ExpectedException.class, () ->
+                createApplicationService.execute(applicationReqDto, 1L));
+
+        String expectedMessage = "존재하지 않는 유저입니다";
+
+        assertEquals(expectedMessage, exception.getMessage());
     }
 }


### PR DESCRIPTION
## 개요

`CreateApplicationServiceImpl`의 단위테스트를 작성하였습니다.

### 피드백

`verifyExistence`메소드가 두번밖에 사용되지 않습니다.
이정도의 재사용성이면 차라리 테스트 메서드 안에서 given을 작성하는게 직관성부분에서 더 좋을까요?