### PR TITLE
CreateApplicationServiceImpl 테스트코드 개선

### DIFF
--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -67,10 +67,6 @@ public class CreateApplicationServiceImplTest {
             1L
     );
 
-    private void givenIdentity() {
-        given(identityRepository.findByUserId(any(Long.class))).willReturn(Optional.of(identity));
-    }
-
     private void verifyExistence() {
         given(applicationRepository.existsByUserId(any(Long.class))).willReturn(false);
         given(userRepository.existsById(any(Long.class))).willReturn(true);
@@ -79,8 +75,8 @@ public class CreateApplicationServiceImplTest {
     @Test
     public void 성공() {
         // given
-        givenIdentity();
         verifyExistence();
+        given(identityRepository.findByUserId(any(Long.class))).willReturn(Optional.of(identity));
 
         // when & then
         assertDoesNotThrow(() -> createApplicationService.execute(applicationReqDto, 1L));

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -99,4 +99,19 @@ public class CreateApplicationServiceImplTest {
 
         assertEquals(expectedMessage, exception.getMessage());
     }
+
+    @Test
+    public void 이미_존재하는_Application() {
+        // given
+        given(userRepository.existsById(any(Long.class))).willReturn(true);
+        given(applicationRepository.existsByUserId(any(Long.class))).willReturn(true);
+
+        // when & then
+        ExpectedException exception = assertThrows(ExpectedException.class, () ->
+                createApplicationService.execute(applicationReqDto, 1L));
+
+        String expectedMessage = "원서가 이미 존재합니다";
+
+        assertEquals(expectedMessage, exception.getMessage());
+    }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -1,0 +1,87 @@
+package team.themoment.hellogsm.web.domain.application.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.themoment.hellogsm.entity.domain.application.entity.Application;
+import team.themoment.hellogsm.entity.domain.application.enums.Gender;
+import team.themoment.hellogsm.entity.domain.application.enums.GraduationStatus;
+import team.themoment.hellogsm.entity.domain.identity.entity.Identity;
+import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
+import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
+import team.themoment.hellogsm.web.domain.application.service.impl.CreateApplicationServiceImpl;
+import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
+import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class CreateApplicationServiceImplTest {
+
+    @InjectMocks
+    private CreateApplicationServiceImpl createApplicationService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private IdentityRepository identityRepository;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    private final ApplicationReqDto applicationReqDto = new ApplicationReqDto(
+            "https://naver.com",
+            "지원자 집주소",
+            "지원자 상세주소",
+            "GED",
+            "01012341234",
+            "홍길동",
+            "부",
+            "01044447777",
+            "김철수",
+            "01077774444",
+            "SW",
+            "AI",
+            "IOT",
+            "{\"curriculumScoreSubtotal\":100,\"nonCurriculumScoreSubtotal\":100,\"rankPercentage\":0,\"scoreTotal\":261}",
+            "지원자 학교 이름",
+            "지원자 학교 위치",
+           "GENERAL"
+    );
+
+    private final Identity identity = new Identity(
+            1L,
+            "차무식",
+            "01012345678",
+            LocalDate.EPOCH,
+            Gender.MALE,
+            1L
+    );
+
+    private void givenIdentity() {
+        given(identityRepository.findByUserId(any(Long.class))).willReturn(Optional.of(identity));
+    }
+
+    private void verifyExistence() {
+        given(applicationRepository.existsByUserId(any(Long.class))).willReturn(false);
+        given(userRepository.existsById(any(Long.class))).willReturn(true);
+    }
+
+    @Test
+    public void 성공() {
+        // given
+        givenIdentity();
+        verifyExistence();
+
+        // when & then
+        assertDoesNotThrow(() -> createApplicationService.execute(applicationReqDto, 1L));
+    }
+}

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -114,4 +114,19 @@ public class CreateApplicationServiceImplTest {
 
         assertEquals(expectedMessage, exception.getMessage());
     }
+
+    @Test
+    public void 존재하지_않는_Identity() {
+        //given
+        verifyExistence();
+        given(identityRepository.findByUserId(any(Long.class))).willReturn(Optional.empty());
+
+        // when & then
+        ExpectedException exception = assertThrows(ExpectedException.class, () ->
+                createApplicationService.execute(applicationReqDto, 1L));
+
+        String expectedMessage = "Identity가 존재하지 않습니다";
+
+        assertEquals(expectedMessage, exception.getMessage());
+    }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -82,12 +82,7 @@ public class CreateApplicationServiceImplTest {
         given(userRepository.existsById(any(Long.class))).willReturn(false);
 
         // when & then
-        ExpectedException exception = assertThrows(ExpectedException.class, () ->
-                createApplicationService.execute(applicationReqDto, 1L));
-
-        String expectedMessage = "존재하지 않는 유저입니다";
-
-        assertEquals(expectedMessage, exception.getMessage());
+        assertExpectedExceptionWithMessage("존재하지 않는 유저입니다");
     }
 
     @Test
@@ -97,12 +92,7 @@ public class CreateApplicationServiceImplTest {
         given(applicationRepository.existsByUserId(any(Long.class))).willReturn(true);
 
         // when & then
-        ExpectedException exception = assertThrows(ExpectedException.class, () ->
-                createApplicationService.execute(applicationReqDto, 1L));
-
-        String expectedMessage = "원서가 이미 존재합니다";
-
-        assertEquals(expectedMessage, exception.getMessage());
+        assertExpectedExceptionWithMessage("원서가 이미 존재합니다");
     }
 
     @Test
@@ -112,10 +102,12 @@ public class CreateApplicationServiceImplTest {
         given(identityRepository.findByUserId(any(Long.class))).willReturn(Optional.empty());
 
         // when & then
+        assertExpectedExceptionWithMessage("Identity가 존재하지 않습니다");
+    }
+
+    private void assertExpectedExceptionWithMessage(String expectedMessage) {
         ExpectedException exception = assertThrows(ExpectedException.class, () ->
                 createApplicationService.execute(applicationReqDto, 1L));
-
-        String expectedMessage = "Identity가 존재하지 않습니다";
 
         assertEquals(expectedMessage, exception.getMessage());
     }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateApplicationServiceImplTest {
@@ -58,14 +59,7 @@ public class CreateApplicationServiceImplTest {
            "GENERAL"
     );
 
-    private final Identity identity = new Identity(
-            1L,
-            "차무식",
-            "01012345678",
-            LocalDate.EPOCH,
-            Gender.MALE,
-            1L
-    );
+    private final Identity identity = mock(Identity.class);
 
     private void verifyExistence() {
         given(applicationRepository.existsByUserId(any(Long.class))).willReturn(false);
@@ -76,7 +70,7 @@ public class CreateApplicationServiceImplTest {
     public void 성공() {
         // given
         verifyExistence();
-        given(identityRepository.findByUserId(any(Long.class))).willReturn(Optional.of(identity));
+        given(identityRepository.findByUserId(any(Long.class))).willReturn(Optional.ofNullable(identity));
 
         // when & then
         assertDoesNotThrow(() -> createApplicationService.execute(applicationReqDto, 1L));

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -101,7 +101,7 @@ public class CreateApplicationServiceImplTest {
         verifyExistence();
         given(identityRepository.findByUserId(any(Long.class))).willReturn(Optional.empty());
 
-        // when & thenㅍ
+        // when & then
         assertExpectedExceptionWithMessage("Identity가 존재하지 않습니다");
     }
 

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/service/CreateApplicationServiceImplTest.java
@@ -14,11 +14,12 @@ import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepo
 import team.themoment.hellogsm.web.domain.application.service.impl.CreateApplicationServiceImpl;
 import team.themoment.hellogsm.web.domain.identity.repository.IdentityRepository;
 import team.themoment.hellogsm.web.domain.user.repository.UserRepository;
+import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
 
 import java.time.LocalDate;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
@@ -83,5 +84,19 @@ public class CreateApplicationServiceImplTest {
 
         // when & then
         assertDoesNotThrow(() -> createApplicationService.execute(applicationReqDto, 1L));
+    }
+
+    @Test
+    public void 존재하지_않는_User() {
+        // given
+        given(userRepository.existsById(any(Long.class))).willReturn(false);
+
+        // when & then
+        ExpectedException exception = assertThrows(ExpectedException.class, () ->
+                createApplicationService.execute(applicationReqDto, 1L));
+
+        String expectedMessage = "존재하지 않는 유저입니다";
+
+        assertEquals(expectedMessage, exception.getMessage());
     }
 }


### PR DESCRIPTION
## 개요

- 데이터의 내용이 아닌 플로우에 대해 검증하기 때문에 더미데이터로 만든 Identity객체가 필요하지 않다고 생각되어 Mock객체를 사용하도록 변경하엿습니다.
- 예외상황에 대한 테스트코드에서 중복되는 부분을 `assertExpectedExceptionWithMessage`메서드로 추출하였습니다.