### PR TITLE
엑셀 다운로드 기능 추가

### DIFF
--- a/hellogsm-web/build.gradle
+++ b/hellogsm-web/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 
     /** for business **/
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.3'
 
     /** for test **/
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/hellogsm-web/src/docs/asciidoc/index.adoc
+++ b/hellogsm-web/src/docs/asciidoc/index.adoc
@@ -554,7 +554,7 @@ operation::application/tickets[snippets='http-response,response-fields']
     ROLE_ADMIN
 
 ==== Request
-operation::application/excel[snippets='curl-request,http-request']
+operation::application/download-excel[snippets='curl-request,http-request']
 
 ==== Response
-operation::application/excel[snippets='http-response,response-fields']
+operation::application/download-excel[snippets='http-response']

--- a/hellogsm-web/src/docs/asciidoc/index.adoc
+++ b/hellogsm-web/src/docs/asciidoc/index.adoc
@@ -544,3 +544,17 @@ operation::application/tickets[snippets='curl-request,http-request']
 
 ==== Response
 operation::application/tickets[snippets='http-response,response-fields']
+
+=== [GET] excel
+엑셀을 다운로드하는 엔드포인트입니다.
+
+시트는 일반전형/사회전형/특별전형/불합격 으로 나뉘어집니다.
+
+==== 사용 가능한 권한
+    ROLE_ADMIN
+
+==== Request
+operation::application/excel[snippets='curl-request,http-request']
+
+==== Response
+operation::application/excel[snippets='http-response,response-fields']

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -1,5 +1,6 @@
 package team.themoment.hellogsm.web.domain.application.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.web.multipart.MultipartFile;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReqDto;
@@ -44,6 +45,7 @@ public class ApplicationController {
     private final QueryTicketsService queryTicketsService;
     private final ImageSaveService imageSaveService;
     private final FinalSubmissionService finalSubmissionService;
+    private final DownloadExcelService downloadExcelService;
 
     @GetMapping("/application/{userId}")
     public ResponseEntity<SingleApplicationRes> readOne(@PathVariable("userId") Long userId) {
@@ -131,5 +133,11 @@ public class ApplicationController {
     public ResponseEntity<Map<String, String>> finalSubmission() {
         finalSubmissionService.execute(manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "수정되었습니다"));
+    }
+
+    @GetMapping(value = "/excel", produces = "applicaton/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8")
+    public ResponseEntity<Void> downloadExcel(HttpServletResponse response) {
+        downloadExcelService.execute(response);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -136,8 +136,8 @@ public class ApplicationController {
     }
 
     @GetMapping(value = "/excel", produces = "applicaton/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8")
-    public ResponseEntity<Map<String, String>> downloadExcel(HttpServletResponse response) {
+    public ResponseEntity<Void> downloadExcel(HttpServletResponse response) {
         downloadExcelService.execute(response);
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "다운로드되었습니다."));
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -134,10 +134,9 @@ public class ApplicationController {
         finalSubmissionService.execute(manager.getId());
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "수정되었습니다"));
     }
-
-    @GetMapping(value = "/excel", produces = "applicaton/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8")
-    public ResponseEntity<Void> downloadExcel(HttpServletResponse response) {
+    @GetMapping("/excel")
+    public ResponseEntity<Map<String, String>> downloadExcel(HttpServletResponse response) {
         downloadExcelService.execute(response);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "다운로드되었습니다"));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -135,8 +135,10 @@ public class ApplicationController {
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "수정되었습니다"));
     }
     @GetMapping("/excel")
-    public ResponseEntity<Map<String, String>> downloadExcel(HttpServletResponse response) {
+    public ResponseEntity<Void> downloadExcel(HttpServletResponse response) {
         downloadExcelService.execute(response);
-        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "다운로드되었습니다"));
+        response.setHeader("Content-Type","applicaton/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8");
+        response.setHeader("Content-Disposition", "attachment;filename=test.xlsx");
+        return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -136,8 +136,8 @@ public class ApplicationController {
     }
 
     @GetMapping(value = "/excel", produces = "applicaton/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8")
-    public ResponseEntity<Void> downloadExcel(HttpServletResponse response) {
+    public ResponseEntity<Map<String, String>> downloadExcel(HttpServletResponse response) {
         downloadExcelService.execute(response);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "다운로드되었습니다."));
     }
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/repository/ApplicationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
 import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
+import team.themoment.hellogsm.entity.domain.application.enums.Screening;
 
 import java.util.List;
 import java.util.Optional;
@@ -41,4 +42,16 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     void deleteApplicationByUserId(Long userId);
 
     List<Application> findAllByAdmissionStatus_FirstEvaluation(EvaluationStatus evaluationStatus);
+
+    List<Application> findAllByAdmissionStatusSecondEvaluation(EvaluationStatus evaluationStatus);
+
+    Boolean existsByAdmissionStatusFirstEvaluation(EvaluationStatus evaluationStatus);
+
+    Boolean existsByAdmissionStatusSecondEvaluation(EvaluationStatus evaluationStatus);
+
+    List<Application> findAllByAdmissionInfoScreening(Screening screening);
+
+    List<Application> findAllByAdmissionStatusScreeningFirstEvaluationAt(Screening screening);
+
+    List<Application> findAllByAdmissionStatusScreeningSecondEvaluationAt(Screening screening);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/DownloadExcelService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/DownloadExcelService.java
@@ -1,0 +1,10 @@
+package team.themoment.hellogsm.web.domain.application.service;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * 원서의 정보를 엑셀로 다운로드하는 service interface 입니다.
+ */
+public interface DownloadExcelService {
+    void execute(HttpServletResponse response);
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DownloadExcelServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DownloadExcelServiceImpl.java
@@ -1,0 +1,154 @@
+package team.themoment.hellogsm.web.domain.application.service.impl;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+import team.themoment.hellogsm.entity.domain.application.entity.Application;
+import team.themoment.hellogsm.entity.domain.application.enums.EvaluationStatus;
+import team.themoment.hellogsm.entity.domain.application.enums.Screening;
+import team.themoment.hellogsm.web.domain.application.mapper.ApplicationMapper;
+import team.themoment.hellogsm.web.domain.application.repository.ApplicationRepository;
+import team.themoment.hellogsm.web.domain.application.service.DownloadExcelService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * 원서의 정보를 엑셀로 다운로드하는 service implementation 입니다.
+ */
+@Service
+@RequiredArgsConstructor
+public class DownloadExcelServiceImpl implements DownloadExcelService {
+
+    private final ApplicationRepository applicationRepository;
+    private final ApplicationMapper applicationMapper;
+
+    Workbook workbook = new XSSFWorkbook();
+    Sheet generalUserSheet = workbook.createSheet("일반전형");
+    Sheet socialUserSheet = workbook.createSheet("사회전형");
+    Sheet specialUserSheet = workbook.createSheet("특별전형");
+    Sheet failedUsersheet = workbook.createSheet("불합격");
+    List<Sheet> sheetList = List.of(generalUserSheet, socialUserSheet, specialUserSheet, failedUsersheet);
+
+    List<String> headerNameList = List.of(
+            "순번",
+            "접수번호",
+            "성명",
+            "1지망",
+            "2지망",
+            "3지망",
+            "생년월일",
+            "성별",
+            "지역명",
+            "출신학교",
+            "학력",
+            "전형구분",
+            "1차합격전형",
+            "2차합격전형",
+            "일반교과점수",
+            "예체능점수",
+            "비교과점수",
+            "출석점수",
+            "봉사점수",
+            "전형총점",
+            "인적성평가점수",
+            "최종점수",
+            "지원자연락처",
+            "부모연락처",
+            "담임연락처"
+    );
+
+    /**
+     * 일반전형/사회전형/특별전형/불합격 총 4개의 시트를 포함한 엑셀을 생성하여 반환합니다.
+     *
+     * @param response (HttpServletResponse) 엑셀을 담는 용도
+     */
+    @Override
+    public void execute(HttpServletResponse response) {
+        List<List<List<String>>> sheetDataList = getSheetDataList();
+
+        for (int i = 0; i < sheetList.size(); i++) {
+            int rowCount = 0;
+
+            Sheet sheet = sheetList.get(i);
+            Row row = sheet.createRow(rowCount++);
+
+            addDataToRow(row, headerNameList);
+
+            List<List<String>> sheetData = sheetDataList.get(i);
+
+            for (List<String> data : sheetData) {
+                row = sheet.createRow(rowCount++);
+                addDataToRow(row, data);
+            }
+        }
+
+
+        response.setContentType("applicaton/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition", "attachment;filename=test.xlsx");
+
+        try {
+            workbook.write(response.getOutputStream());
+            workbook.close();
+        } catch (IOException ex) {
+            throw new RuntimeException("파일 작성과정에서 예외가 발생하였습니다.");
+        }
+    }
+
+    private List<List<List<String>>> getSheetDataList() {
+        List<List<String>> generalSheetData;
+        List<List<String>> socialSheetData;
+        List<List<String>> specialSheetData;
+        List<List<String>> falledSheetData = new ArrayList<>();
+
+        if (applicationRepository.existsByAdmissionStatusFirstEvaluation(EvaluationStatus.NOT_YET)) {
+            generalSheetData = applicationMapper.INSTANCE.applicationToExcelDataList(applicationRepository.findAllByAdmissionInfoScreening(Screening.GENERAL), false);
+            socialSheetData = applicationMapper.INSTANCE.applicationToExcelDataList(applicationRepository.findAllByAdmissionInfoScreening(Screening.SOCIAL), false);
+            List<Application> combinedSpecialAppList = Stream.concat(
+                            applicationRepository.findAllByAdmissionInfoScreening(Screening.SPECIAL_VETERANS).stream(),
+                            applicationRepository.findAllByAdmissionInfoScreening(Screening.SPECIAL_ADMISSION).stream()
+                    )
+                    .toList();
+            specialSheetData = applicationMapper.INSTANCE.applicationToExcelDataList(combinedSpecialAppList, false);
+        } else {
+            if (applicationRepository.existsByAdmissionStatusSecondEvaluation(EvaluationStatus.NOT_YET)) {
+                generalSheetData = applicationMapper.INSTANCE.applicationToExcelDataList(applicationRepository.findAllByAdmissionStatusScreeningFirstEvaluationAt(Screening.GENERAL), false);
+                socialSheetData = applicationMapper.INSTANCE.applicationToExcelDataList(applicationRepository.findAllByAdmissionStatusScreeningFirstEvaluationAt(Screening.SOCIAL), false);
+                List<Application> combinedSpecialAppList = Stream.concat(
+                                applicationRepository.findAllByAdmissionStatusScreeningFirstEvaluationAt(Screening.SPECIAL_VETERANS).stream(),
+                                applicationRepository.findAllByAdmissionStatusScreeningFirstEvaluationAt(Screening.SPECIAL_ADMISSION).stream()
+                        )
+                        .toList();
+                specialSheetData = applicationMapper.INSTANCE.applicationToExcelDataList(combinedSpecialAppList, false);
+                falledSheetData = applicationMapper.INSTANCE.applicationToExcelDataList(applicationRepository.findAllByAdmissionStatus_FirstEvaluation(EvaluationStatus.FALL), false);
+
+            } else {
+                generalSheetData = applicationMapper.INSTANCE.applicationToExcelDataList(applicationRepository.findAllByAdmissionStatusScreeningSecondEvaluationAt(Screening.GENERAL), true);
+                socialSheetData = applicationMapper.INSTANCE.applicationToExcelDataList(applicationRepository.findAllByAdmissionStatusScreeningSecondEvaluationAt(Screening.SOCIAL), true);
+                List<Application> combinedSpecialAppList = Stream.concat(
+                                applicationRepository.findAllByAdmissionStatusScreeningSecondEvaluationAt(Screening.SPECIAL_VETERANS).stream(),
+                                applicationRepository.findAllByAdmissionStatusScreeningSecondEvaluationAt(Screening.SPECIAL_ADMISSION).stream()
+                        )
+                        .toList();
+                specialSheetData = applicationMapper.INSTANCE.applicationToExcelDataList(combinedSpecialAppList, true);
+                falledSheetData = applicationMapper.INSTANCE.applicationToExcelDataList(applicationRepository.findAllByAdmissionStatusSecondEvaluation(EvaluationStatus.FALL), true);
+            }
+        }
+
+        return List.of(generalSheetData, socialSheetData, specialSheetData, falledSheetData);
+    }
+
+    private void addDataToRow(Row row, List<String> data) {
+        for (int k = 0; k < headerNameList.size(); k++) {
+            Cell cell = row.createCell(k);
+            cell.setCellValue(data.get(k));
+        }
+    }
+}

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DownloadExcelServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DownloadExcelServiceImpl.java
@@ -6,6 +6,7 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.stereotype.Service;
 import team.themoment.hellogsm.entity.domain.application.entity.Application;
@@ -30,7 +31,7 @@ public class DownloadExcelServiceImpl implements DownloadExcelService {
     private final ApplicationRepository applicationRepository;
     private final ApplicationMapper applicationMapper;
 
-    Workbook workbook = new XSSFWorkbook();
+    Workbook workbook = new SXSSFWorkbook();
     Sheet generalUserSheet = workbook.createSheet("일반전형");
     Sheet socialUserSheet = workbook.createSheet("사회전형");
     Sheet specialUserSheet = workbook.createSheet("특별전형");

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DownloadExcelServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DownloadExcelServiceImpl.java
@@ -91,8 +91,6 @@ public class DownloadExcelServiceImpl implements DownloadExcelService {
             }
         }
 
-        response.setHeader("Content-Disposition", "attachment;filename=test.xlsx");
-
         try {
             workbook.write(response.getOutputStream());
             workbook.close();

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DownloadExcelServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/DownloadExcelServiceImpl.java
@@ -90,8 +90,6 @@ public class DownloadExcelServiceImpl implements DownloadExcelService {
             }
         }
 
-
-        response.setContentType("applicaton/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         response.setHeader("Content-Disposition", "attachment;filename=test.xlsx");
 
         try {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -204,6 +204,9 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.PUT, "/application/v1/status/*").hasAnyRole(
                         Role.ROLE_ADMIN.getRole()
                 )
+                .requestMatchers("/application/v1/excel").hasAnyRole(
+                        Role.ROLE_ADMIN.getRole()
+                )
                 .anyRequest().permitAll()
         );
     }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -766,9 +766,10 @@ class ApplicationControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .cookie(new Cookie("SESSION", "SESSIONID12345")))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(header().stringValues("Content-Type", "applicaton/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8"))
                 .andDo(this.documentationHandler.document(
                         requestSessionCookie()
                 ));
+
     }
 }

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -2,6 +2,7 @@ package team.themoment.hellogsm.web.domain.application.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -15,7 +16,6 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.restdocs.cookies.RequestCookiesSnippet;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.MockMvc;
@@ -32,7 +32,6 @@ import team.themoment.hellogsm.web.domain.application.dto.response.*;
 import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationStatusReqDto;
 import team.themoment.hellogsm.web.domain.application.enums.SearchTag;
 import team.themoment.hellogsm.web.domain.application.service.*;
-import team.themoment.hellogsm.web.domain.common.ControllerTestUtil;
 import team.themoment.hellogsm.web.global.security.auth.AuthenticatedUserManager;
 
 import java.math.BigDecimal;
@@ -92,6 +91,8 @@ class ApplicationControllerTest {
     private ImageSaveService imageSaveService;
     @MockBean
     private FinalSubmissionService finalSubmissionService;
+    @MockBean
+    private DownloadExcelService downloadExcelService;
 
 
     protected final FieldDescriptor[] gedResponseFields = new FieldDescriptor[]{
@@ -747,6 +748,21 @@ class ApplicationControllerTest {
         doNothing().when(finalSubmissionService).execute(any(Long.class));
 
         this.mockMvc.perform(put("/application/v1/final-submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new Cookie("SESSION", "SESSIONID12345")))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andDo(this.documentationHandler.document(
+                        requestSessionCookie()
+                ));
+    }
+
+    @Test
+    @DisplayName("엑셀 다운로드")
+    void downloadExcel() throws Exception {
+        doNothing().when(downloadExcelService).execute(any(HttpServletResponse.class));
+
+        this.mockMvc.perform(get("/application/v1/excel")
                         .contentType(MediaType.APPLICATION_JSON)
                         .cookie(new Cookie("SESSION", "SESSIONID12345")))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## 개요

엑셀 다운로드 기능을 추가하였습니다.

## 본문

일반전형/사회전형/특별전형/불합격 총 4개의 시트를 포함한 엑셀을 다운로드 합니다.
for문을 통한 반복적인 구문을 없애기 위함과 null인 데이터를 공백으로 만들기 위하여 데이터를 전부 String으로 바꿔 처리하였습니다.
그러나 String으로 변환하는 위치가 mapper에 위치하여 원래 mapper의 목적과 맞지 않다고 생각됩니다.
어제 시준선배와 대화 나눠본 결과 일단 mapper에서 처리하고 추후 리팩토링 진행하기로 결정하였습니다.

### 추가

- `org.apache.poi` 라이브러리 추가
- `DownloadExcelService` 정의 및 구현
- `ApplicationController` : `downloadExcel` 메서드 추가
- `ApplicationMapper`: `applicationToExcelDataList` 메서드 추가
- `SecurityConfig` : 엑셀 다운로드 api 권한 제한 추가
- `ApplicationRepository`: 1차, 2차평가가 이루어졌는지 확인하는 메서드, 지원전형/1차합격전형/2차합격전형의 값으로 원서를 조회하는 메서드 추가
- `index.adoc` : 엑셀 다운로드 api 문서 추가