### PR TITLE
`ApplicationStatusReqDto` `@Pattern` 정규표현식 범위가 잘못 설정된 문제

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationStatusReqDto.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/dto/request/ApplicationStatusReqDto.java
@@ -21,17 +21,17 @@ public record ApplicationStatusReqDto(
         @NotBlank
         String secondEvaluation,
 
-        @Pattern(regexp = "^(GENERAL|SOCIAL|SPECIAL_VETERANS|SPECIAL_ADMISSION|)$") // null 포함
+        @Pattern(regexp = "^(GENERAL|SOCIAL|SPECIAL_VETERANS|SPECIAL_ADMISSION)$")
         String screeningFirstEvaluationAt,
 
-        @Pattern(regexp = "^(GENERAL|SOCIAL|SPECIAL_VETERANS|SPECIAL_ADMISSION|)$") // null 포함
+        @Pattern(regexp = "^(GENERAL|SOCIAL|SPECIAL_VETERANS|SPECIAL_ADMISSION)$")
         String screeningSecondEvaluationAt,
 
         Long registrationNumber,
 
         BigDecimal secondScore,
 
-        @Pattern(regexp = "^(AI|IOT|SW|)$") // null 포함
+        @Pattern(regexp = "^(AI|IOT|SW)$") 
         String finalMajor
 ) {
 }


### PR DESCRIPTION
## 개요
#245 에서 설명하는
`ApplicationStatusReqDto`의 일부 필드에서 `@Pattern` 사용이 잘못되어 유효성 검사가 통과되는 문제를 수정하였습니다.