### PR TITLE
누락된 기능인 admin 원서 수정 기능 추가

### DIFF
--- a/hellogsm-web/src/docs/asciidoc/index.adoc
+++ b/hellogsm-web/src/docs/asciidoc/index.adoc
@@ -473,6 +473,18 @@ operation::application/modify[snippets='curl-request,http-request,request-fields
 ==== Response
 operation::application/modify[snippets='http-response']
 
+=== [PUT] application/{userId}
+USER ID를 사용하여 특정 사용자의 원서를 수정하는 엔드포인트입니다.
+
+==== 사용 가능한 권한
+    ROLE_ADMIN
+
+==== Request
+operation::application/modify-by-id[snippets='curl-request,http-request,request-fields']
+
+==== Response
+operation::application/modify-by-id[snippets='http-response']
+
 === [DELETE] application/me
 현재 사용자의 원서를 삭제하는 엔드포인트입니다.
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -65,6 +65,14 @@ public class ApplicationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("message", "생성되었습니다"));
     }
 
+    @PutMapping("/application/{userId}")
+    public ResponseEntity<Map<String, String>> modifyOne(
+            @RequestBody @Valid ApplicationReqDto body,
+            @PathVariable Long userId) {
+        modifyApplicationService.execute(body, userId);
+        return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "수정되었습니다"));
+    }
+
     @PutMapping("/application/me")
     public ResponseEntity<Map<String, String>> modify(
             @RequestBody @Valid ApplicationReqDto body

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -202,6 +202,12 @@ public class SecurityConfig {
                 ).hasAnyRole(
                         Role.ROLE_ADMIN.getRole()
                 )
+                .requestMatchers(
+                        HttpMethod.PUT,
+                        "/application/v1/application/*"
+                ).hasAnyRole(
+                        Role.ROLE_ADMIN.getRole()
+                )
                 .requestMatchers(HttpMethod.PUT, "/application/v1/status/*").hasAnyRole(
                         Role.ROLE_ADMIN.getRole()
                 )

--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -474,6 +474,23 @@ class ApplicationControllerTest {
     }
 
     @Test
+    @DisplayName("입력받은 USER ID로 원서 수정")
+    void modifyById() throws Exception {
+        doNothing().when(modifyApplicationService).execute(any(ApplicationReqDto.class), any(Long.class));
+
+        this.mockMvc.perform(put("/application/v1/application/1")
+                        .content(objectMapper.writeValueAsString(applicationReqDto))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .cookie(new Cookie("SESSION", "SESSIONID12345")))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andDo(this.documentationHandler.document(
+                        requestSessionCookie(),
+                        requestFields(createRequestFields)
+                ));
+    }
+
+    @Test
     @DisplayName("원서 전체 조회")
     void findAll() throws Exception {
         ApplicationListDto applicationListDto = new ApplicationListDto(


### PR DESCRIPTION
## 개요

admin 원서 수정 기능이 누락되어 추가하였습니다.

## 본문

로직은 기존의 원서 수정 로직과 동일하며, controller 매핑과 테스트코드, API 명세서, 인가 설정을 추가하였습니다.