### PR TITLE
원서 수정 요청 어드민 여부에 따라서 분기처리 추가

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationController.java
@@ -69,7 +69,7 @@ public class ApplicationController {
     public ResponseEntity<Map<String, String>> modifyOne(
             @RequestBody @Valid ApplicationReqDto body,
             @PathVariable Long userId) {
-        modifyApplicationService.execute(body, userId);
+        modifyApplicationService.execute(body, userId, true);
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "수정되었습니다"));
     }
 
@@ -77,7 +77,7 @@ public class ApplicationController {
     public ResponseEntity<Map<String, String>> modify(
             @RequestBody @Valid ApplicationReqDto body
     ) {
-        modifyApplicationService.execute(body, manager.getId());
+        modifyApplicationService.execute(body, manager.getId(), false);
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("message", "수정되었습니다"));
     }
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ModifyApplicationService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ModifyApplicationService.java
@@ -6,5 +6,5 @@ import team.themoment.hellogsm.web.domain.application.dto.request.ApplicationReq
  * 현재 사용자의 원서를 수정하는 service interface 입니다.
  */
 public interface ModifyApplicationService {
-    void execute(ApplicationReqDto body, Long userId);
+    void execute(ApplicationReqDto body, Long userId, boolean isAdmin);
 }

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationServiceImpl.java
@@ -39,13 +39,13 @@ public class ModifyApplicationServiceImpl implements ModifyApplicationService {
      *      4. 본인인증 정보가 존재하지 않을 경우 <br>
      */
     @Override
-    public void execute(ApplicationReqDto body, Long userId) {
+    public void execute(ApplicationReqDto body, Long userId, boolean isAdmin) {
         if (!userRepository.existsById(userId))
             throw new ExpectedException("존재하지 않는 유저입니다", HttpStatus.BAD_REQUEST);
 
         Application application = applicationRepository.findByUserId(userId)
                 .orElseThrow(() -> new ExpectedException("원서가 존재하지 않습니다", HttpStatus.BAD_REQUEST));
-        if (application.getAdmissionStatus().isFinalSubmitted())
+        if (!isAdmin && application.getAdmissionStatus().isFinalSubmitted())
             throw new ExpectedException("최종제출이 완료된 원서입니다", HttpStatus.BAD_REQUEST);
 
         Identity identity = identityRepository.findByUserId(userId)


### PR DESCRIPTION
## 개요

원서 수정 요청 시, 어드민이라면 최종제출 된 원서도 수정 가능하지만, 입학 신청 학생인 경우는 최종제출 이후 원서 수정이 불가능하도록 변경하였습니다.
