### PR TITLE
ApplicationControllerTest 누락된 ModifyApplicationService 변경사항 반영하도록 수정

### DIFF
--- a/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
+++ b/hellogsm-web/src/test/java/team/themoment/hellogsm/web/domain/application/controller/ApplicationControllerTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
@@ -459,7 +460,7 @@ class ApplicationControllerTest {
     @Test
     @DisplayName("원서 수정")
     void modify() throws Exception {
-        doNothing().when(modifyApplicationService).execute(any(ApplicationReqDto.class), any(Long.class));
+        doNothing().when(modifyApplicationService).execute(any(ApplicationReqDto.class), any(Long.class), anyBoolean());
 
         this.mockMvc.perform(put("/application/v1/application/me")
                         .content(objectMapper.writeValueAsString(applicationReqDto))
@@ -476,7 +477,7 @@ class ApplicationControllerTest {
     @Test
     @DisplayName("입력받은 USER ID로 원서 수정")
     void modifyById() throws Exception {
-        doNothing().when(modifyApplicationService).execute(any(ApplicationReqDto.class), any(Long.class));
+        doNothing().when(modifyApplicationService).execute(any(ApplicationReqDto.class), any(Long.class), anyBoolean());
 
         this.mockMvc.perform(put("/application/v1/application/1")
                         .content(objectMapper.writeValueAsString(applicationReqDto))


### PR DESCRIPTION
## 개요

ApplicationControllerTest에서 ModifyApplicationService 변경사항을 누락하여 테스트가 실패하던 문제를 수정하였습니다.

