### PR TITLE
원서 수정 시 일부 데이터가 초기화되는 버그 해결

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -259,6 +259,67 @@ public interface ApplicationMapper {
         );
     }
 
+    default Application updateApplicationByApplicationReqDtoAndApplication(ApplicationReqDto applicationReqDto, Application application) {
+
+        Long appId = application.getId();
+        Long userId = application.getUserId();
+        AdmissionInfo oldAdmissionInfo = application.getAdmissionInfo();
+        AdmissionStatus oldAdmissionStatus = application.getAdmissionStatus();
+
+
+        DesiredMajor desiredMajor = DesiredMajor.builder()
+                .firstDesiredMajor(Major.valueOf(applicationReqDto.firstDesiredMajor()))
+                .secondDesiredMajor(Major.valueOf(applicationReqDto.secondDesiredMajor()))
+                .thirdDesiredMajor(Major.valueOf(applicationReqDto.thirdDesiredMajor()))
+                .build();
+
+        AdmissionInfo admissionInfo = AdmissionInfo.builder()
+                .id(userId)
+                .applicantImageUri(applicationReqDto.applicantImageUri())
+                .applicantName(oldAdmissionInfo.getApplicantName())
+                .applicantGender(oldAdmissionInfo.getApplicantGender())
+                .applicantBirth(oldAdmissionInfo.getApplicantBirth())
+                .address(applicationReqDto.address())
+                .detailAddress(applicationReqDto.detailAddress())
+                .graduation(GraduationStatus.valueOf(applicationReqDto.graduation()))
+                .telephone(applicationReqDto.telephone())
+                .applicantPhoneNumber(oldAdmissionInfo.getApplicantPhoneNumber())
+                .guardianName(applicationReqDto.guardianName())
+                .relationWithApplicant(applicationReqDto.relationWithApplicant())
+                .guardianPhoneNumber(applicationReqDto.guardianPhoneNumber())
+                .teacherName(applicationReqDto.teacherName())
+                .teacherPhoneNumber(applicationReqDto.teacherPhoneNumber())
+                .screening(Screening.valueOf(applicationReqDto.screening()))
+                .schoolName(applicationReqDto.schoolName())
+                .schoolLocation(applicationReqDto.schoolLocation())
+                .desiredMajor(desiredMajor)
+                .build();
+
+        AdmissionStatus admissionStatus = AdmissionStatus
+                .builder()
+                .id(oldAdmissionStatus.getId())
+                .isFinalSubmitted(oldAdmissionStatus.isFinalSubmitted())
+                .isPrintsArrived(oldAdmissionStatus.isPrintsArrived())
+                .firstEvaluation(oldAdmissionStatus.getFirstEvaluation())
+                .secondEvaluation(oldAdmissionStatus.getSecondEvaluation())
+                .screeningFirstEvaluationAt(OptionalUtils.fromOptional(oldAdmissionStatus.getScreeningFirstEvaluationAt()))
+                .screeningSecondEvaluationAt(OptionalUtils.fromOptional(oldAdmissionStatus.getScreeningFirstEvaluationAt()))
+                .registrationNumber(OptionalUtils.fromOptional(oldAdmissionStatus.getRegistrationNumber()))
+                .secondScore(OptionalUtils.fromOptional(oldAdmissionStatus.getSecondScore()))
+                .finalMajor(OptionalUtils.fromOptional(oldAdmissionStatus.getFinalMajor()))
+                .build();
+
+        MiddleSchoolGrade middleSchoolGrade = new MiddleSchoolGrade(userId, applicationReqDto.middleSchoolGrade());
+
+        return new Application(
+                appId,
+                admissionInfo,
+                admissionStatus,
+                middleSchoolGrade,
+                userId
+        );
+    }
+
     @BeanMapping(ignoreUnmappedSourceProperties = {
             "userId",
             "applicantName",
@@ -331,7 +392,7 @@ public interface ApplicationMapper {
         } else {
             sortedList = applicationList.stream()
                     .sorted(Comparator.comparing(application ->
-                            application.getAdmissionGrade().getTotalScore(),
+                                    application.getAdmissionGrade().getTotalScore(),
                             Comparator.reverseOrder())
                     )
                     .toList();

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/impl/ModifyApplicationServiceImpl.java
@@ -48,12 +48,11 @@ public class ModifyApplicationServiceImpl implements ModifyApplicationService {
         if (!isAdmin && application.getAdmissionStatus().isFinalSubmitted())
             throw new ExpectedException("최종제출이 완료된 원서입니다", HttpStatus.BAD_REQUEST);
 
-        Identity identity = identityRepository.findByUserId(userId)
-                .orElseThrow(() -> new ExpectedException("Identity가 존재하지 않습니다", HttpStatus.BAD_REQUEST));
-
-        IdentityDto identityDto = IdentityMapper.INSTANCE.identityToIdentityDto(identity);
+        if(!identityRepository.existsByUserId(userId)) {
+            throw new ExpectedException("Identity가 존재하지 않습니다", HttpStatus.BAD_REQUEST);
+        }
 
         applicationRepository.save(
-                ApplicationMapper.INSTANCE.applicationReqDtoAndIdentityDtoToApplication(body, identityDto, userId, application.getId()));
+                ApplicationMapper.INSTANCE.updateApplicationByApplicationReqDtoAndApplication(body, application));
     }
 }


### PR DESCRIPTION
## 개요

원서 수정 시 일부 데이터가 초기화되는 버그를 해결하였습니다,

## 본문

원서 수정 시 로직이 원서 생성 시 로직과 동일한 매퍼를 사용하여, 특정 값이 초기화되는 문제가 있었습니다.
원서 수정 시 사용하는 매퍼를 추가하고, 적용하여 버그를 해결하였습니다.
