### PR TITLE
SecurityConfig 인증/인가 엔드포인트 지정 잘못된 문제 수정

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -195,7 +195,7 @@ public class SecurityConfig {
                 )
                 .requestMatchers(
                         HttpMethod.GET,
-                        "/application/v1/ticket",
+                        "/application/v1/tickets",
                         "/application/v1/application/all",
                         "/application/v1/application/search",
                         "/application/v1/application/*"


### PR DESCRIPTION
## 개요

SecurityConfig 인증/인가 엔드포인트 지정 잘못되었던 문제를 수정하였습니다.

## 본문

잘못 작성된 엔드포인트 올바르게 변경 
`/application/v1/ticket` -> `/application/v1/tickets`

현재 서비스에서 지원하는 모든 엔드포인트를 확인해보았고, 위 엔드포인트 이외에는 문제 없었습니다.

