### PR TITLE
cicd script 절대경로 -> 상대경로 변경

### DIFF
--- a/.github/workflows/hello-gsm-prod-batch-CD.yml
+++ b/.github/workflows/hello-gsm-prod-batch-CD.yml
@@ -1,4 +1,4 @@
-name: HelloGSM dev batch CD workflow
+name: HelloGSM prod batch CD workflow
 
 on:
   push:

--- a/appspec.yml
+++ b/appspec.yml
@@ -14,6 +14,6 @@ permissions:
 
 hooks:
   ApplicationStart:
-    - location: scripts/deploy.sh
+    - location: /home/ec2-user/builds/scripts/deploy.sh
       timeout: 60
       runas: root

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,12 +5,12 @@ DEPLOYMENT_GROUP_NAME=$(echo $DEPLOYMENT_GROUP_NAME)
 
 # 배포 그룹에 따라 다른 작업을 수행합니다.
 if [ "$DEPLOYMENT_GROUP_NAME" == "dev-web-server" ]; then
-  chmod +x scripts/web-dev-deploy.sh
-  scripts/web-dev-deploy.sh
+  chmod +x /home/ec2-user/builds/scripts/web-dev-deploy.sh
+  /home/ec2-user/builds/scripts/web-dev-deploy.sh
 
 elif [ "$DEPLOYMENT_GROUP_NAME" == "prod-web-server" ]; then
-  chmod +x scripts/web-prod-deploy.sh
-  scripts/web-prod-deploy.sh
+  chmod +x /home/ec2-user/builds/scripts/web-prod-deploy.sh
+  /home/ec2-user/builds/scripts/web-prod-deploy.sh
 
 else
   echo "batch deploy"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,12 +5,12 @@ DEPLOYMENT_GROUP_NAME=$(echo $DEPLOYMENT_GROUP_NAME)
 
 # 배포 그룹에 따라 다른 작업을 수행합니다.
 if [ "$DEPLOYMENT_GROUP_NAME" == "dev-web-server" ]; then
-  chmod +x /scripts/web-dev-deploy.sh
-  /scripts/web-dev-deploy.sh
+  chmod +x scripts/web-dev-deploy.sh
+  scripts/web-dev-deploy.sh
 
 elif [ "$DEPLOYMENT_GROUP_NAME" == "prod-web-server" ]; then
-  chmod +x /scripts/web-prod-deploy.sh
-  /scripts/web-prod-deploy.sh
+  chmod +x scripts/web-prod-deploy.sh
+  scripts/web-prod-deploy.sh
 
 else
   echo "batch deploy"

--- a/scripts/web-dev-deploy.sh
+++ b/scripts/web-dev-deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-BUILD_JAR=$(ls /home/ec2-user/builds/*.jar)
+BUILD_JAR=$(ls /home/ec2-user/builds/hellogsm-web/build/libs/*.jar)
 JAR_NAME=$(basename $BUILD_JAR)
 
 DEPLOY_PATH=/home/ec2-user/

--- a/scripts/web-prod-deploy.sh
+++ b/scripts/web-prod-deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-BUILD_JAR=$(ls /home/ec2-user/builds/*.jar)
+BUILD_JAR=$(ls /home/ec2-user/builds/hellogsm-web/build/libs/*.jar)
 JAR_NAME=$(basename $BUILD_JAR)
 
 DEPLOY_PATH=/home/ec2-user/


### PR DESCRIPTION
## 개요

cicd script 절대경로에서 상대경로로 변경

## 본문

script 파일 내부의 절대경로로 하면 파일 위치를 못찾기때문에 상대경로로 appspec.yml과 일치 시켰습니다.

추가적으로 prod batch workflow 이름 잘못되있길래 변경하였습니다.

### 변경

deploy.sh 파일 내부의 `/scripts/*` -> `script/*` 로 변경하였습니다.