### PR TITLE
prod 환경 logback 설정 추가

### DIFF
--- a/hellogsm-batch/src/main/resources/logback-spring.xml
+++ b/hellogsm-batch/src/main/resources/logback-spring.xml
@@ -126,10 +126,6 @@
             <appender-ref ref="ROLLING-FILE"/>
             <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
         </logger>
-        <logger name="org.hibernate.orm.jdbc.bind" level="INFO">
-            <appender-ref ref="ROLLING-FILE"/>
-            <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
-        </logger>
         <logger name="team.themoment.hellogsm" level="INFO">
             <appender-ref ref="ROLLING-FILE"/>
             <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>

--- a/hellogsm-batch/src/main/resources/logback-spring.xml
+++ b/hellogsm-batch/src/main/resources/logback-spring.xml
@@ -28,7 +28,7 @@
     </springProfile>
 
 
-    <springProfile name="local | dev | prod">
+    <springProfile name="dev">
 
         <!--로그 파일 저장, 혹시 모를 Backup 용 -->
         <appender name="ROLLING-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -77,6 +77,60 @@
             <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
         </logger>
         <logger name="team.themoment.hellogsm" level="trace">
+            <appender-ref ref="ROLLING-FILE"/>
+            <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
+        </logger>
+    </springProfile>
+
+    <springProfile name="prod">
+
+        <!--로그 파일 저장, 혹시 모를 Backup 용 -->
+        <appender name="ROLLING-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/backup/${LOG_NAME}.log</file>
+            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+                <charset>${FILE_LOG_CHARSET}</charset>
+            </encoder>
+            <!-- ${LOG_NAME}이 이름인 파일(<file> 로 정의한)에 작성되다가 Rolling 조건이 되면
+            파일 이름이 ${LOG_NAME}-2022-02-22.0 으로 변경되어 저장, 이후 새로운 파일 ${LOG_NAME} 파일에 로그가 작성됨 -->
+            <!-- cloudwatch 조건으로 ${LOG_NAME}이 prefix인 로그를 저장하라고 설정하기 -->
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/backup/${LOG_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                    <maxFileSize>10MB</maxFileSize>
+                </timeBasedFileNamingAndTriggeringPolicy>
+                <maxHistory>365</maxHistory>
+                <totalSizeCap>10GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <!-- 로그 AWS CloudWatch Logs 에 등록하기 위한 로그 파일, 데이터가 많이 발생하면 기존 데이터를 대체함 -->
+        <!-- CloudWatch Agent 가 해당 파일을 읽고 로그를 전송함 -->
+        <appender name="FILE-FOR-CLOUD-WATCH" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/cloudwatch/${LOG_NAME}.log</file>
+            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+                <charset>${FILE_LOG_CHARSET}</charset>
+            </encoder>
+            <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+                <maxFileSize>10MB</maxFileSize> <!-- 각 파일의 최대 크기 -->
+            </triggeringPolicy>
+            <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/cloudwatch/${LOG_NAME}.%i.log</fileNamePattern>
+                <minIndex>1</minIndex>
+                <maxIndex>10</maxIndex> <!-- 최대 파일 수 (10개로 설정) -->
+            </rollingPolicy>
+        </appender>
+
+        <logger name="org.springframework" level="INFO">
+            <appender-ref ref="ROLLING-FILE"/>
+            <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
+        </logger>
+        <logger name="org.hibernate.orm.jdbc.bind" level="INFO">
+            <appender-ref ref="ROLLING-FILE"/>
+            <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
+        </logger>
+        <logger name="team.themoment.hellogsm" level="INFO">
             <appender-ref ref="ROLLING-FILE"/>
             <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
         </logger>

--- a/hellogsm-web/src/main/resources/logback-spring.xml
+++ b/hellogsm-web/src/main/resources/logback-spring.xml
@@ -126,10 +126,6 @@
             <appender-ref ref="ROLLING-FILE"/>
             <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
         </logger>
-        <logger name="org.hibernate.orm.jdbc.bind" level="INFO">
-            <appender-ref ref="ROLLING-FILE"/>
-            <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
-        </logger>
         <logger name="team.themoment.hellogsm" level="INFO">
             <appender-ref ref="ROLLING-FILE"/>
             <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>

--- a/hellogsm-web/src/main/resources/logback-spring.xml
+++ b/hellogsm-web/src/main/resources/logback-spring.xml
@@ -28,7 +28,7 @@
     </springProfile>
 
 
-    <springProfile name="dev | prod">
+    <springProfile name="dev">
 
         <!--로그 파일 저장, 혹시 모를 Backup 용 -->
         <appender name="ROLLING-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -77,6 +77,60 @@
             <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
         </logger>
         <logger name="team.themoment.hellogsm" level="trace">
+            <appender-ref ref="ROLLING-FILE"/>
+            <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
+        </logger>
+    </springProfile>
+
+    <springProfile name="prod">
+
+        <!--로그 파일 저장, 혹시 모를 Backup 용 -->
+        <appender name="ROLLING-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/backup/${LOG_NAME}.log</file>
+            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+                <charset>${FILE_LOG_CHARSET}</charset>
+            </encoder>
+            <!-- ${LOG_NAME}이 이름인 파일(<file> 로 정의한)에 작성되다가 Rolling 조건이 되면
+            파일 이름이 ${LOG_NAME}-2022-02-22.0 으로 변경되어 저장, 이후 새로운 파일 ${LOG_NAME} 파일에 로그가 작성됨 -->
+            <!-- cloudwatch 조건으로 ${LOG_NAME}이 prefix인 로그를 저장하라고 설정하기 -->
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/backup/${LOG_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                    <maxFileSize>10MB</maxFileSize>
+                </timeBasedFileNamingAndTriggeringPolicy>
+                <maxHistory>365</maxHistory>
+                <totalSizeCap>10GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <!-- 로그 AWS CloudWatch Logs 에 등록하기 위한 로그 파일, 데이터가 많이 발생하면 기존 데이터를 대체함 -->
+        <!-- CloudWatch Agent 가 해당 파일을 읽고 로그를 전송함 -->
+        <appender name="FILE-FOR-CLOUD-WATCH" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/cloudwatch/${LOG_NAME}.log</file>
+            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+                <charset>${FILE_LOG_CHARSET}</charset>
+            </encoder>
+            <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+                <maxFileSize>10MB</maxFileSize> <!-- 각 파일의 최대 크기 -->
+            </triggeringPolicy>
+            <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/cloudwatch/${LOG_NAME}.%i.log</fileNamePattern>
+                <minIndex>1</minIndex>
+                <maxIndex>10</maxIndex> <!-- 최대 파일 수 (10개로 설정) -->
+            </rollingPolicy>
+        </appender>
+
+        <logger name="org.springframework" level="INFO">
+            <appender-ref ref="ROLLING-FILE"/>
+            <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
+        </logger>
+        <logger name="org.hibernate.orm.jdbc.bind" level="INFO">
+            <appender-ref ref="ROLLING-FILE"/>
+            <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
+        </logger>
+        <logger name="team.themoment.hellogsm" level="INFO">
             <appender-ref ref="ROLLING-FILE"/>
             <appender-ref ref="FILE-FOR-CLOUD-WATCH"/>
         </logger>


### PR DESCRIPTION
## 개요
기존에는 dev,prod를 통합하여 관리하였지만,
prod 환경 logback 설정을  분리하여 관리하도록 변경하였습니다.

## 본문
INFO 레벨 이상의 로그를 cloudwatch용 file, backup용 file로 작성되도록 구현하였습니다.


