### PR TITLE
Tester 권한추가 및 TimeBasedFilter 예외조건 추가

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/user/enums/Role.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/user/enums/Role.java
@@ -4,6 +4,7 @@ public enum Role {
 
     ROLE_UNAUTHENTICATED("UNAUTHENTICATED"),
     ROLE_USER("USER"),
+    ROLE_TESTER("TESTER"), // prod 환경에서 기간 상관없이 테스트 가능한 USER
     ROLE_ADMIN("ADMIN");
 
     private final String role;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -77,7 +77,8 @@ public class SecurityConfig {
                             .requestMatchers(HttpMethod.POST, "/identity/v1/identity/me/send-code-test")
                             .hasAnyRole(
                                     Role.ROLE_UNAUTHENTICATED.getRole(),
-                                    Role.ROLE_USER.getRole())
+                                    Role.ROLE_USER.getRole(),
+                                    Role.ROLE_TESTER.getRole())
             );
             authorizeHttpRequests(http);
             exceptionHandling(http);
@@ -151,25 +152,30 @@ public class SecurityConfig {
                 // user
                 .requestMatchers(HttpMethod.GET, "/user/v1/user/me").hasAnyRole(
                         Role.ROLE_UNAUTHENTICATED.getRole(),
-                        Role.ROLE_USER.getRole()
+                        Role.ROLE_USER.getRole(),
+                        Role.ROLE_TESTER.getRole()
                 )
                 .requestMatchers(HttpMethod.DELETE, "/user/v1/user/me").hasAnyRole(
                         Role.ROLE_UNAUTHENTICATED.getRole(),
-                        Role.ROLE_USER.getRole()
+                        Role.ROLE_USER.getRole(),
+                        Role.ROLE_TESTER.getRole()
                 )
                 .requestMatchers(HttpMethod.GET, "/user/v1/user/*").hasAnyRole(
                         Role.ROLE_ADMIN.getRole()
                 )
                 // identity
                 .requestMatchers(HttpMethod.GET, "/identity/v1/identity/me").hasAnyRole(
-                        Role.ROLE_USER.getRole()
+                        Role.ROLE_USER.getRole(),
+                        Role.ROLE_TESTER.getRole()
                 )
                 .requestMatchers(HttpMethod.PUT, "/identity/v1/identity/me").hasAnyRole(
-                        Role.ROLE_USER.getRole()
+                        Role.ROLE_USER.getRole(),
+                        Role.ROLE_TESTER.getRole()
                 )
                 .requestMatchers(HttpMethod.POST, "/identity/v1/identity/me").hasAnyRole(
                         Role.ROLE_UNAUTHENTICATED.getRole(),
                         Role.ROLE_USER.getRole(),
+                        Role.ROLE_TESTER.getRole(),
                         Role.ROLE_ADMIN.getRole()
                 )
                 .requestMatchers(
@@ -177,20 +183,24 @@ public class SecurityConfig {
                         "/identity/v1/identity/me/send-code",
                         "/identity/me/auth-code").hasAnyRole(
                         Role.ROLE_UNAUTHENTICATED.getRole(),
-                        Role.ROLE_USER.getRole()
+                        Role.ROLE_USER.getRole(),
+                        Role.ROLE_TESTER.getRole()
                 )
                 .requestMatchers(HttpMethod.GET, "/identity/v1/identity/*").hasAnyRole(
                         Role.ROLE_ADMIN.getRole()
                 )
                 // application
                 .requestMatchers("/application/v1/application/me").hasAnyRole(
-                        Role.ROLE_USER.getRole()
+                        Role.ROLE_USER.getRole(),
+                        Role.ROLE_TESTER.getRole()
                 )
                 .requestMatchers(HttpMethod.PUT, "/application/v1/final-submit").hasAnyRole(
-                        Role.ROLE_USER.getRole()
+                        Role.ROLE_USER.getRole(),
+                        Role.ROLE_TESTER.getRole()
                 )
                 .requestMatchers(HttpMethod.POST, "/application/v1/image").hasAnyRole(
                         Role.ROLE_USER.getRole(),
+                        Role.ROLE_TESTER.getRole(),
                         Role.ROLE_ADMIN.getRole()
                 )
                 .requestMatchers(

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/filter/TimeBasedFilter.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/filter/TimeBasedFilter.java
@@ -9,12 +9,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.filter.OncePerRequestFilter;
+import team.themoment.hellogsm.entity.domain.user.enums.Role;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 public class TimeBasedFilter extends OncePerRequestFilter {
@@ -43,6 +49,14 @@ public class TimeBasedFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (!isOAuthAuth()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        if (isSkipAble()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
         String requestUrl = request.getRequestURI();
         HttpMethod requestMethod;
         try {
@@ -69,6 +83,19 @@ public class TimeBasedFilter extends OncePerRequestFilter {
             }
         }
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isSkipAble() {
+        OAuth2User oAuth2User = (OAuth2User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String authRole = Objects.requireNonNull(oAuth2User.getAttribute("role")).toString();
+        boolean isTester = Role.ROLE_TESTER.name().equals(authRole);
+        boolean isAdmin = Role.ROLE_ADMIN.name().equals(authRole);
+        return isTester || isAdmin;
+    }
+
+    private boolean isOAuthAuth() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return auth instanceof OAuth2AuthenticationToken;
     }
 
     private void sendErrorResponse(HttpServletResponse response, String message) throws IOException {


### PR DESCRIPTION
## 개요

TESTER 권한을 추가하고, TimeBasedFilter 예외조건을 추가하였습니다.

## 본문

#### `TESTER` 추가
`USER`와 동일한 권한을 가지며, PROD 환경에서 테스트를 하기 위해 추가되었습니다.
`TimeBasedFilter`의 조건에서 제외되어 실제 운영 시간대가 아니더라도 요청이 처리됩니다.

#### `TimeBasedFilter` 예외 조건
다음과 같은 조건에서 SKIP 됩니다.
1. OAuth 인증을 사용하지 않은 사용자. ex) `AnonymousAuthetationToken`
2. `ADMIN` 혹은 `TESTER` 권한을 가지는 사용자

