### PR TITLE
AWS SMS에 사용되는 maxPrice 설정값 제거

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/SendSmsServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/SendSmsServiceImpl.java
@@ -18,7 +18,6 @@ import team.themoment.hellogsm.web.global.thirdParty.aws.service.template.AwsTem
 @RequiredArgsConstructor
 @Slf4j
 public class SendSmsServiceImpl implements SendSmsService {
-    private final static String MAX_PRICE = "1.00"; // 서버에서 이게 필요한가? 어차피 AWS 설정하면 되는데
     private final static String SENDER_ID = "hello-gsm";
     private final static String KR_CODE = "+82";
     private final SnsSmsTemplate smsTemplate;
@@ -38,7 +37,6 @@ public class SendSmsServiceImpl implements SendSmsService {
                     message,
                     SmsMessageAttributes.builder()
                             .smsType(SmsType.TRANSACTIONAL)
-                            .maxPrice(MAX_PRICE)
                             .senderID(SENDER_ID)
                             .build()
             );


### PR DESCRIPTION
## 개요

AWS SMS 서비스를 요청하는 `SnsSmsTemplate`의 maxPrice 설정을 사용하지 않도록 변경

## 본문

테스트 시 과도한 비용이 요구되지 않도록 하기 위해서 사용했습니다.
PROD 환경을 위해서 maxPrice 설정을 제거하였습니다.