### PR TITLE
2차 시험 평가 Query 오류 수정

### DIFF
--- a/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/jobSkillsEvaluation/JobSkillsEvaluationJobConfig.java
+++ b/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/jobSkillsEvaluation/JobSkillsEvaluationJobConfig.java
@@ -155,7 +155,7 @@ public class JobSkillsEvaluationJobConfig {
                 .queryString(
                         "SELECT a " +
                                 "FROM Application a " + // TODO 테스트 코드 추가하기
-                                "WHERE a.admissionStatus.firstEvaluation = 'PASS' " +
+                                "WHERE a.admissionStatus.firstEvaluation = 'PASS' AND a.admissionStatus.firstEvaluation IS NOT NULL " +
                                 "ORDER BY a.admissionGrade.totalScore DESC ," +
                                 "(a.admissionGrade.curricularSubtotalScore + a.admissionGrade.artisticScore) DESC, " +
                                 "a.admissionGrade.grade3Semester1Score DESC, " +

--- a/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/jobSkillsEvaluation/JobSkillsEvaluationJobConfig.java
+++ b/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/jobSkillsEvaluation/JobSkillsEvaluationJobConfig.java
@@ -155,7 +155,7 @@ public class JobSkillsEvaluationJobConfig {
                 .queryString(
                         "SELECT a " +
                                 "FROM Application a " + // TODO 테스트 코드 추가하기
-                                "WHERE a.admissionStatus.firstEvaluation = 'PASS' AND a.admissionStatus.firstEvaluation IS NOT NULL " +
+                                "WHERE a.admissionStatus.firstEvaluation = 'PASS' AND a.admissionStatus.screeningFirstEvaluationAt IS NOT NULL " +
                                 "ORDER BY a.admissionGrade.totalScore DESC ," +
                                 "(a.admissionGrade.curricularSubtotalScore + a.admissionGrade.artisticScore) DESC, " +
                                 "a.admissionGrade.grade3Semester1Score DESC, " +


### PR DESCRIPTION
## 개요

2차 시험 평가 Query가 유효하지 않은 데이터를 가져오는 오류를 수정하였습니다.

## 본문

관리자가 합격 여부만을 결정한 경우, `screeningFirstEvaluationAt`가 null 입니다.
하지만 `screeningFirstEvaluationAt`의 값이 null 값에 대한 예외처리가 되어있지 않아서 에러가 발생하였습니다.
`screeningFirstEvaluationAt`가 null이 아닌 경우만 데이터를 조회하도록 Query문을 수정하였습니다.
