### PR TITLE
졸업/졸업 예정자 중학교 예체능 성적 계산로직 버그 수정

### DIFF
--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
@@ -150,16 +150,34 @@ public class GraduateAdmissionGrade extends AdmissionGrade {
     }
 
     private BigDecimal calcArtSports(List<BigDecimal> scoreArray) {
-        if (scoreArray == null || scoreArray.isEmpty()) return BigDecimal.valueOf(0).setScale(3, RoundingMode.HALF_UP);
-        // (A의 개수 * 5) + (B의 개수 * 4) + (C의 개수 * 3)
-        BigDecimal reduceResult = scoreArray.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
-        // reduceResult / (개수 * 5) (소수점 4째 자리에서 반올림)
-        scoreArray = scoreArray.stream()
-                .filter(score -> BigDecimal.ZERO.compareTo(score) != 0)
-                .collect(Collectors.toList());
-        BigDecimal divideResult = reduceResult.divide(BigDecimal.valueOf(scoreArray.size() * 5L), 3, RoundingMode.HALF_UP);
-        return BigDecimal.valueOf(60).multiply(divideResult).setScale(3, RoundingMode.HALF_UP);
+        int aCount = 0;
+        int bCount = 0;
+        int cCount = 0;
+
+        for (BigDecimal score : scoreArray) {
+            if (score.equals(BigDecimal.ZERO)) {
+                continue;
+            } else if (score.equals(BigDecimal.valueOf(5))) {
+                aCount++;
+            } else if (score.equals(BigDecimal.valueOf(4))) {
+                bCount++;
+            } else if (score.equals(BigDecimal.valueOf(3))) {
+                cCount++;
+            }
+        }
+
+        int totalScores = (aCount * 5) + (bCount * 4) + (cCount * 3);
+        int totalSubjects = aCount + bCount + cCount;
+        int maxScore = 5 * totalSubjects;
+
+        if (totalSubjects == 0) {
+            return BigDecimal.valueOf(36).setScale(3, RoundingMode.HALF_UP);
+        }
+
+        BigDecimal accuracyRate = BigDecimal.valueOf(totalScores).divide(BigDecimal.valueOf(maxScore), 3, RoundingMode.HALF_UP);
+        return BigDecimal.valueOf(60).multiply(accuracyRate).setScale(3, RoundingMode.HALF_UP);
     }
+
 
     private BigDecimal calcAttendance(List<BigDecimal> absentScore, List<BigDecimal> attendanceScore) {
         BigDecimal absent = absentScore.stream().reduce(BigDecimal.ZERO, BigDecimal::add);

--- a/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
+++ b/hellogsm-entity/src/main/java/team/themoment/hellogsm/entity/domain/application/entity/grade/GraduateAdmissionGrade.java
@@ -150,8 +150,7 @@ public class GraduateAdmissionGrade extends AdmissionGrade {
     }
 
     private BigDecimal calcArtSports(List<BigDecimal> scoreArray) {
-        if (scoreArray == null) return BigDecimal.valueOf(0).setScale(3, RoundingMode.HALF_UP);
-
+        if (scoreArray == null || scoreArray.isEmpty()) return BigDecimal.valueOf(0).setScale(3, RoundingMode.HALF_UP);
         // (A의 개수 * 5) + (B의 개수 * 4) + (C의 개수 * 3)
         BigDecimal reduceResult = scoreArray.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
         // reduceResult / (개수 * 5) (소수점 4째 자리에서 반올림)


### PR DESCRIPTION
## 개요

로직 구현이 잘못되어 특정 데이터 입력 시 `ArithmeticException` 이 발생하는 문제를 해결하였습니다.

## 본문

자세한 에러 원인에 대한 설명은 [노션 링크](https://www.notion.so/themoment-team/500-HttpStatus-ca49292f86654cd89ec19b8da6be2b98?pvs=4)를 참고해주세요.

로직을 새로 리팩토링 하고, `scoreArray` 값이 모두 `0` 인 경우, 최저점을 반환하도록 예외처리하였습니다.
