### PR TITLE
batch 모듈 logback 패턴에 x-ray trace id 설정 제거

### DIFF
--- a/hellogsm-batch/src/main/resources/logback-spring.xml
+++ b/hellogsm-batch/src/main/resources/logback-spring.xml
@@ -34,7 +34,7 @@
         <appender name="ROLLING-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>${LOG_PATH}/backup/${LOG_NAME}.log</file>
             <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-                <pattern>%X{AWS-XRAY-TRACE-ID} ${FILE_LOG_PATTERN}</pattern>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
                 <charset>${FILE_LOG_CHARSET}</charset>
             </encoder>
             <!-- ${LOG_NAME}이 이름인 파일(<file> 로 정의한)에 작성되다가 Rolling 조건이 되면
@@ -55,7 +55,7 @@
         <appender name="FILE-FOR-CLOUD-WATCH" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>${LOG_PATH}/cloudwatch/${LOG_NAME}.log</file>
             <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-                <pattern>%X{AWS-XRAY-TRACE-ID} ${FILE_LOG_PATTERN}</pattern>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
                 <charset>${FILE_LOG_CHARSET}</charset>
             </encoder>
             <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
@@ -88,7 +88,7 @@
         <appender name="ROLLING-FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>${LOG_PATH}/backup/${LOG_NAME}.log</file>
             <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-                <pattern>%X{AWS-XRAY-TRACE-ID} ${FILE_LOG_PATTERN}</pattern>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
                 <charset>${FILE_LOG_CHARSET}</charset>
             </encoder>
             <!-- ${LOG_NAME}이 이름인 파일(<file> 로 정의한)에 작성되다가 Rolling 조건이 되면
@@ -109,7 +109,7 @@
         <appender name="FILE-FOR-CLOUD-WATCH" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>${LOG_PATH}/cloudwatch/${LOG_NAME}.log</file>
             <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-                <pattern>%X{AWS-XRAY-TRACE-ID} ${FILE_LOG_PATTERN}</pattern>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
                 <charset>${FILE_LOG_CHARSET}</charset>
             </encoder>
             <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">


### PR DESCRIPTION
## 개요

batch 모듈 logback 패턴에 x-ray trace id 설정을 제거하였습니다.
batch 모듈은 x-ray를 사용하지 않기 때문에 의미 없는 값입니다.