### PR TITLE
1차, 2차 평가 배치 - 탈락한 사용자는 n차 합격 전형 값을 null로 가지도록 변경

### DIFF
--- a/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/documentEvaluation/DocumentEvaluationJobConfig.java
+++ b/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/documentEvaluation/DocumentEvaluationJobConfig.java
@@ -177,6 +177,12 @@ public class DocumentEvaluationJobConfig {
             Screening screening = application.getAdmissionInfo().getScreening();
 
             EvaluationResult rs = decisionProvider.evaluate(screening);
+            if (rs.evaluationStatus().equals(EvaluationStatus.FALL)) {
+                rs = new EvaluationResult(
+                        EvaluationStatus.FALL,
+                        null
+                );
+            }
 
             return newAdmissionStatus(oldAdmissionStatus, rs);
         };

--- a/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/jobSkillsEvaluation/JobSkillsEvaluationJobConfig.java
+++ b/hellogsm-batch/src/main/java/team/themoment/hellogsm/batch/jobs/jobSkillsEvaluation/JobSkillsEvaluationJobConfig.java
@@ -176,6 +176,12 @@ public class JobSkillsEvaluationJobConfig {
             Screening screening = oldAdmissionStatus.getScreeningFirstEvaluationAt().get();
 
             EvaluationResult rs = decisionProvider.evaluate(screening);
+            if (rs.evaluationStatus().equals(EvaluationStatus.FALL)) {
+                rs = new EvaluationResult(
+                        EvaluationStatus.FALL,
+                        null
+                );
+            }
 
             return newAdmissionStatus(oldAdmissionStatus, rs);
         };


### PR DESCRIPTION
## 개요

1차 평가를 합격한 사용자의 경우, 1차 합격 시 전형 값을 가집니다. 
2차도 마찬가지로 2차 합격 시 전형 값을 가집니다.

그러나 1,2차 평가에 탈락한 사용자가 1,2차 합격 시 전형 값을 가지는 문제가 발생했습니다.
탈락한 사용자는 n차 합격 전형 값을 null로 가지도록 변경하여 해결하였습니다.

