### PR TITLE
엑셀 보호자전화번호 데이터 오류 수정

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/mapper/ApplicationMapper.java
@@ -456,7 +456,7 @@ public interface ApplicationMapper {
                     String.valueOf(admissionStatus.getSecondScore().orElse(null)),
                     String.valueOf(finalScore),
                     admissionInfo.getApplicantPhoneNumber(),
-                    admissionInfo.getApplicantPhoneNumber(),
+                    admissionInfo.getGuardianPhoneNumber(),
                     String.valueOf(admissionInfo.getTeacherPhoneNumber().orElse(null))
             );
 


### PR DESCRIPTION
## 개요

기존 엑셀에서 `보호자전화번호`셀에 `지원자전화번호`를 넣고 있는 오류가 발견되었습니다.
올바른 값이 들어가도록 수정하였습니다.