### PR TITLE
logout 기능 대체

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/SecurityConfig.java
@@ -131,10 +131,11 @@ public class SecurityConfig {
     }
 
     private void logout(HttpSecurity http) throws Exception {
-        http.logout(logout -> logout
-                .logoutUrl(logoutUri)
-                .logoutSuccessHandler(new CustomUrlLogoutSuccessHandler(authEnv.redirectBaseUri(), authEnv.redirectAdminUri()))
-        );
+//        http.logout(logout -> logout
+//                .logoutUrl(logoutUri)
+//                .logoutSuccessHandler(new CustomUrlLogoutSuccessHandler(authEnv.redirectBaseUri(), authEnv.redirectAdminUri()))
+//        );
+        //TODO session 없이 요청하는 경우에 에러 발생하지 않도록 수정하고 적용하기
     }
 
     private void exceptionHandling(HttpSecurity http) throws Exception {

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthController.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/security/auth/AuthController.java
@@ -1,0 +1,55 @@
+package team.themoment.hellogsm.web.global.security.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.util.UriComponentsBuilder;
+import team.themoment.hellogsm.entity.domain.user.enums.Role;
+
+import java.io.IOException;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/auth/v1")
+public class AuthController {
+
+    private final AuthEnvironment authEnvironment;
+
+
+    // spring security logout 기능 관련 이슈로 인한 임시 구현
+    //TODO 이슈 해결하고 spring security logout으로 대체하기
+    @GetMapping("/logout")
+    public void logout(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof OAuth2AuthenticationToken) {
+            new SecurityContextLogoutHandler().logout(request, response, SecurityContextHolder.getContext().getAuthentication());
+        }
+        String redirectUrl = buildRedirectUrl(isAdmin(auth));
+        response.sendRedirect(redirectUrl);
+
+    }
+
+    protected final boolean isAdmin(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .anyMatch(authority -> Role.ROLE_ADMIN.name().equals(authority.getAuthority()));
+    }
+
+    protected final String buildRedirectUrl(boolean isAdmin) {
+        final String defaultTargetUrl = authEnvironment.redirectBaseUri();
+        final String adminUrl = authEnvironment.redirectBaseUri();
+
+        String targetUrl = isAdmin ? adminUrl : defaultTargetUrl;
+
+        return UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("logout", "success")
+                .build()
+                .toUriString();
+    }
+}


### PR DESCRIPTION
## 개요
세션이 존재하지 않은 상태에서 로그아웃 시 500 에러가 발생하고, whitelabel 페이지로 이동하는 문제가 있습니다. 
자세한 내용은 #290 를 참고해주세요. 

해당 문제를 해결하기 위해 로그아웃 기능을 새롭게 구현하여 대체하였습니다.

## 본문
기존의 HttpSecurity에서 제공하는 로그아웃 기능을 Controller로 구현하여 대체하였습니다.
로그인한 상태의 사용자만 SecurityContextLogoutHandler의 로그아웃을 호출하도록 변경하여, 로그아웃이 이루어지도록 구현하였습니다. 

세션이 없는 사용자가 요청하더라도 `AnonymousAuthenticationFilter`를 거친 후에는 `AnonymousAuthenticationToken`이 할당된 상태이기 때문에 인증 토큰을 문제 없이 가져올 수 있습니다.




