### PR TITLE
인프라 관련 서비스 인터페이스를 도메인 서비스 패키지로 이동

### DIFF
--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ImageUploadService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/ImageUploadService.java
@@ -1,4 +1,4 @@
-package team.themoment.hellogsm.web.global.thirdParty.aws.service.aws;
+package team.themoment.hellogsm.web.domain.application.service;
 
 import org.springframework.web.multipart.MultipartFile;
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/SendSmsService.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/domain/application/service/SendSmsService.java
@@ -1,4 +1,4 @@
-package team.themoment.hellogsm.web.global.thirdParty.aws.service.aws;
+package team.themoment.hellogsm.web.domain.application.service;
 
 /**
  * phoneNumber와 message를 받아서 message를 보내는 인터페이스입니다.

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/application/impl/ImageSaveServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/application/impl/ImageSaveServiceImpl.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import team.themoment.hellogsm.web.domain.application.service.ImageSaveService;
 import team.themoment.hellogsm.web.global.exception.error.ExpectedException;
-import team.themoment.hellogsm.web.global.thirdParty.aws.service.aws.ImageUploadService;
+import team.themoment.hellogsm.web.domain.application.service.ImageUploadService;
 
 import java.util.Objects;
 

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/ImageUploadServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/ImageUploadServiceImpl.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
-import team.themoment.hellogsm.web.global.thirdParty.aws.service.aws.ImageUploadService;
+import team.themoment.hellogsm.web.domain.application.service.ImageUploadService;
 import team.themoment.hellogsm.web.global.thirdParty.aws.service.template.AwsTemplate;
 
 import java.time.LocalDateTime;

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/SendSmsServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/aws/impl/SendSmsServiceImpl.java
@@ -7,7 +7,7 @@ import io.awspring.cloud.sns.sms.SnsSmsTemplate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import team.themoment.hellogsm.web.global.thirdParty.aws.service.aws.SendSmsService;
+import team.themoment.hellogsm.web.domain.application.service.SendSmsService;
 import team.themoment.hellogsm.web.global.thirdParty.aws.service.template.AwsTemplate;
 
 /**

--- a/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/identity/Impl/CodeNotificationServiceImpl.java
+++ b/hellogsm-web/src/main/java/team/themoment/hellogsm/web/global/thirdParty/aws/service/identity/Impl/CodeNotificationServiceImpl.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import team.themoment.hellogsm.web.domain.identity.service.CodeNotificationService;
-import team.themoment.hellogsm.web.global.thirdParty.aws.service.aws.SendSmsService;
+import team.themoment.hellogsm.web.domain.application.service.SendSmsService;
 
 /**
  * CodeNotificationService의 구현체입니다.


### PR DESCRIPTION
## 개요

인프라 관련 서비스 인터페이스의 위치를 변경하였습니다.
`web.global.thirdParty.aws.service.aws` -> `web.domain.application.service` 로 옮겼습니다.

## 본문
현재 service 패키지에서 global에 존재하는 인프라 관련 서비스 인터페이스를 참조하고 있습니다.

인프라 관련 서비스 인터페이스는 외부 서드파티의 의존성을 가지지 않습니다.
따라서 인프라 관련 서비스 객체를 service 패키지로 이동하여 Core 패키지인 service가 global 패키지를 의존하지 않도록 변경하였습니다.

#### 전 후 패키지 의존성 비교
<img width="1469" alt="image" src="https://github.com/themoment-team/hellogsm-server/assets/80192911/faf8d9ea-840a-4386-988a-32a0f97216d2">

